### PR TITLE
Remove calls to affine at some places in ECP and ECP2

### DIFF
--- a/c/ecp.c
+++ b/c/ecp.c
@@ -232,7 +232,7 @@ int ECP_ZZZ_set(ECP_ZZZ *P, BIG_XXX x)
     FP_YYY_nres(&rhs, x);
 
     ECP_ZZZ_rhs(&rhs, &rhs);
-    
+
     //FP_YYY_redc(b, &rhs);
     //if (BIG_XXX_jacobi(b, m) != 1)
     if (!FP_YYY_qr(&rhs,NULL))
@@ -476,7 +476,7 @@ void ECP_ZZZ_map2point(ECP_ZZZ *P,FP_YYY *h)
 
     FP_YYY_mul(&X1,&t,&A);
     FP_YYY_neg(&X1,&X1);
-    
+
     FP_YYY_copy(&X2,&X1);
     FP_YYY_add(&X2,&X2,&A); FP_YYY_norm(&X2);
     FP_YYY_neg(&X2,&X2);
@@ -491,7 +491,7 @@ void ECP_ZZZ_map2point(ECP_ZZZ *P,FP_YYY *h)
         FP_YYY_add(&w1,&w1,&t);   // w1=X1^3+AX1^2+BX1
     } else {
         FP_YYY_add(&w1,&w1,&X1);
-    }    
+    }
     FP_YYY_norm(&w1);
 
     FP_YYY_norm(&X2);
@@ -514,14 +514,14 @@ void ECP_ZZZ_map2point(ECP_ZZZ *P,FP_YYY *h)
 
     if (!rfc)
     {
-        FP_YYY_mul(&X1,&X1,&K);  
-        FP_YYY_mul(&Y,&Y,&K);    
+        FP_YYY_mul(&X1,&X1,&K);
+        FP_YYY_mul(&Y,&Y,&K);
     }
     ne=sgn^FP_YYY_sign(&Y);
     FP_YYY_neg(&NY,&Y); FP_YYY_norm(&NY);
     FP_YYY_cmove(&Y,&NY,ne);
 
-#if MODTYPE_YYY == GENERALISED_MERSENNE  
+#if MODTYPE_YYY == GENERALISED_MERSENNE
 // GOLDILOCKS isogeny
     FP_YYY_sqr(&t,&X1);  // t=u^2
     FP_YYY_add(&NY,&t,&one); // NY=u^2+1
@@ -539,9 +539,9 @@ void ECP_ZZZ_map2point(ECP_ZZZ *P,FP_YYY *h)
     FP_YYY_norm(&Y);        // 4v^2
     FP_YYY_add(&w2,&t,&Y);  // w2=(u^2-1)^2+4v^2
     FP_YYY_norm(&w2);
-    FP_YYY_inv(&w2,&w2);    
+    FP_YYY_inv(&w2,&w2);
     FP_YYY_mul(&w1,&w1,&w2); // w1=4v(u^2-1)/[(u^2-1)^2+4v^2]
-    
+
     FP_YYY_sub(&w2,&Y,&t);   // w2=4v^2-(u^2-1)^2
     FP_YYY_norm(&w2);
     FP_YYY_mul(&w2,&w2,&X1); // w2=u(4v^2-(u^2-1)^2)
@@ -564,7 +564,7 @@ void ECP_ZZZ_map2point(ECP_ZZZ *P,FP_YYY *h)
     FP_YYY_mul(&X1,&X1,&t);
 
     if (rfc)
-        FP_YYY_mul(&X1,&X1,&K);  
+        FP_YYY_mul(&X1,&X1,&K);
 
     FP_YYY_mul(&Y,&Y,&w2);
     FP_YYY_mul(&Y,&Y,&t);
@@ -575,12 +575,12 @@ void ECP_ZZZ_map2point(ECP_ZZZ *P,FP_YYY *h)
     return;
 #endif
 #if CURVETYPE_ZZZ==WEIERSTRASS
-// SWU method. 
+// SWU method.
     int sgn,ne;
     BIG_XXX a,x,y;
     FP_YYY X1,X2,X3,t,w,one,A,B,Y,j,NY;
     FP_YYY_rcopy(&B,CURVE_B_ZZZ);
-    
+
     FP_YYY_one(&one);
     FP_YYY_copy(&t,h);
     sgn=FP_YYY_sign(&t);
@@ -597,13 +597,13 @@ void ECP_ZZZ_map2point(ECP_ZZZ *P,FP_YYY *h)
         FP_YYY_imul(&t,&t,RIADZ_YYY);
 
     //    FP_YYY_norm(&t);
-        FP_YYY_add(&w,&t,&one);  
+        FP_YYY_add(&w,&t,&one);
         FP_YYY_norm(&w);
         FP_YYY_mul(&w,&w,&t);    // w=t2(t2+1)
         FP_YYY_mul(&A,&A,&w);     // A=Aw
         FP_YYY_inv(&A,&A);
         FP_YYY_add(&w,&w,&one); FP_YYY_norm(&w);
-        FP_YYY_mul(&w,&w,&B);     
+        FP_YYY_mul(&w,&w,&B);
         FP_YYY_neg(&w,&w);      // -B(w+1)
         FP_YYY_norm(&w);
         FP_YYY_mul(&X2,&w,&A);   // -B(w+1)/Aw
@@ -618,10 +618,10 @@ void ECP_ZZZ_map2point(ECP_ZZZ *P,FP_YYY *h)
 // Shallue and van de Woestijne
         FP_YYY_from_int(&Y,RIADZ_YYY);
         ECP_ZZZ_rhs(&A,&Y);  // A=g(Z)
-        FP_YYY_sqr(&t,&t);   
+        FP_YYY_sqr(&t,&t);
         FP_YYY_mul(&Y,&A,&t);   // tv1=u^2*g(Z)
         FP_YYY_add(&t,&one,&Y); FP_YYY_norm(&t); // tv2=1+tv1
-        FP_YYY_sub(&Y,&one,&Y); FP_YYY_norm(&Y); // tv1=1-tv1 
+        FP_YYY_sub(&Y,&one,&Y); FP_YYY_norm(&Y); // tv1=1-tv1
         FP_YYY_mul(&NY,&t,&Y);
         FP_YYY_inv(&NY,&NY);     // tv3=inv0(tv1*tv2)
         FP_YYY_neg(&A,&A); FP_YYY_norm(&A);     // -g(Z)
@@ -638,7 +638,7 @@ void ECP_ZZZ_map2point(ECP_ZZZ *P,FP_YYY *h)
         FP_YYY_sub(&X1,&X1,&w); FP_YYY_norm(&X1);
         FP_YYY_add(&X2,&X2,&w); FP_YYY_norm(&X2);
         FP_YYY_add(&A,&A,&A);
-        FP_YYY_add(&A,&A,&A); 
+        FP_YYY_add(&A,&A,&A);
         FP_YYY_norm(&A);      // -4*g(Z)
         FP_YYY_sqr(&t,&t);
         FP_YYY_mul(&t,&t,&NY);
@@ -655,7 +655,7 @@ void ECP_ZZZ_map2point(ECP_ZZZ *P,FP_YYY *h)
         FP_YYY_cmove(&X3,&X1,FP_YYY_qr(&w,NULL));
         ECP_ZZZ_rhs(&w,&X3);
         FP_YYY_sqrt(&Y,&w,NULL);
-        FP_YYY_redc(x,&X3); 
+        FP_YYY_redc(x,&X3);
 
 /*
         FP_YYY_from_int(&A,-3);
@@ -663,7 +663,7 @@ void ECP_ZZZ_map2point(ECP_ZZZ *P,FP_YYY *h)
         FP_YYY_sub(&j,&w,&one);  FP_YYY_norm(&j);
         FP_YYY_div2(&j,&j);        // j=(w-1)/2
         FP_YYY_mul(&w,&w,&t);     // w=s.t
-        FP_YYY_add(&B,&B,&one);   
+        FP_YYY_add(&B,&B,&one);
         FP_YYY_sqr(&Y,&t);
         FP_YYY_add(&B,&B,&Y);    // t^2+b+1
         FP_YYY_norm(&B);
@@ -674,9 +674,9 @@ void ECP_ZZZ_map2point(ECP_ZZZ *P,FP_YYY *h)
         FP_YYY_neg(&X2,&X1);
         FP_YYY_sub(&X2,&X2,&one);
         FP_YYY_norm(&X2);
-        FP_YYY_sqr(&w,&w); FP_YYY_inv(&w,&w); 
+        FP_YYY_sqr(&w,&w); FP_YYY_inv(&w,&w);
         FP_YYY_add(&X3,&w,&one); FP_YYY_norm(&X3);
-    
+
         ECP_ZZZ_rhs(&w,&X2);
         FP_YYY_cmove(&X1,&X2,FP_YYY_qr(&w,NULL));
         ECP_ZZZ_rhs(&w,&X3);
@@ -1333,7 +1333,6 @@ void ECP_ZZZ_pinmul(ECP_ZZZ *P, int e, int bts)
         ECP_ZZZ_cswap(&R0, &R1, b);
     }
     ECP_ZZZ_copy(P, &R0);
-    ECP_ZZZ_affine(P);
 }
 #endif
 
@@ -1357,7 +1356,6 @@ void ECP_ZZZ_mul(ECP_ZZZ *P, BIG_XXX e)
     ECP_ZZZ_dbl(&R1);
 
     ECP_ZZZ_copy(&D, P);
-    ECP_ZZZ_affine(&D);
 
     nb = BIG_XXX_nbits(e);
     for (i = nb - 2; i >= 0; i--)
@@ -1387,8 +1385,6 @@ void ECP_ZZZ_mul(ECP_ZZZ *P, BIG_XXX e)
         ECP_ZZZ_inf(P);
         return;
     }
-
-    ECP_ZZZ_affine(P);
 
     /* precompute table */
 
@@ -1442,7 +1438,6 @@ void ECP_ZZZ_mul(ECP_ZZZ *P, BIG_XXX e)
     }
     ECP_ZZZ_sub(P, &C); /* apply correction */
 #endif
-    ECP_ZZZ_affine(P);
 }
 
 #if CURVETYPE_ZZZ!=MONTGOMERY
@@ -1534,7 +1529,6 @@ void ECP_ZZZ_mul2(ECP_ZZZ *P, ECP_ZZZ *Q, BIG_XXX e, BIG_XXX f)
         ECP_ZZZ_add(P, &T);
     }
     ECP_ZZZ_sub(P, &C); /* apply correction */
-    ECP_ZZZ_affine(P);
 }
 
 #endif

--- a/c/ecp2.c
+++ b/c/ecp2.c
@@ -197,9 +197,9 @@ void ECP2_ZZZ_toOctet(octet *W, ECP2_ZZZ *Q, bool compress)
         W->len = 4 * MODBYTES_XXX+1;
     } else {
         W->val[0]=0x02;
-        if (FP2_YYY_sign(&qy)==1) W->val[0] = 0x03; 
+        if (FP2_YYY_sign(&qy)==1) W->val[0] = 0x03;
         W->len = 2 * MODBYTES_XXX + 1;
-    }    
+    }
 
 }
 
@@ -225,7 +225,7 @@ int ECP2_ZZZ_fromOctet(ECP2_ZZZ *Q, octet *W)
         if (ECP2_ZZZ_set(Q, &qx, &qy)) return 1;
     } else {
         if (ECP2_ZZZ_setx(Q, &qx, typ&1)) return 1;
-    }    
+    }
     return 0;
 }
 
@@ -530,7 +530,6 @@ void ECP2_ZZZ_mul(ECP2_ZZZ *P, BIG_XXX e)
         ECP2_ZZZ_add(P, &Q);
     }
     ECP2_ZZZ_sub(P, &C); /* apply correction */
-    ECP2_ZZZ_affine(P);
 }
 
 /* Calculates q.P using Frobenius constant X */
@@ -637,8 +636,6 @@ void ECP2_ZZZ_mul4(ECP2_ZZZ *P, ECP2_ZZZ Q[4], BIG_XXX u[4])
     ECP2_ZZZ_copy(&W, P);
     ECP2_ZZZ_sub(&W, &Q[0]);
     ECP2_ZZZ_cmove(P, &W, pb);
-
-    ECP2_ZZZ_affine(P);
 }
 
 /* Hunt and Peck a BIG to a curve point */
@@ -681,10 +678,10 @@ void ECP2_ZZZ_map2point(ECP2_ZZZ *Q,FP2_YYY *H)
 
     FP2_YYY_from_ints(&Z,RIADZG2A_YYY,RIADZG2B_YYY);
     ECP2_ZZZ_rhs(&A,&Z);  // A=g(Z)
-    FP2_YYY_sqr(&T,&T);   
+    FP2_YYY_sqr(&T,&T);
     FP2_YYY_mul(&Y,&A,&T);   // tv1=u^2*g(Z)
     FP2_YYY_add(&T,&W,&Y); FP2_YYY_norm(&T); // tv2=1+tv1
-    FP2_YYY_sub(&Y,&W,&Y); FP2_YYY_norm(&Y); // tv1=1-tv1 
+    FP2_YYY_sub(&Y,&W,&Y); FP2_YYY_norm(&Y); // tv1=1-tv1
     FP2_YYY_mul(&NY,&T,&Y);
     FP2_YYY_inv(&NY,&NY);     // tv3=inv0(tv1*tv2)
     FP2_YYY_neg(&A,&A); FP2_YYY_norm(&A);     // -g(Z)
@@ -701,7 +698,7 @@ void ECP2_ZZZ_map2point(ECP2_ZZZ *Q,FP2_YYY *H)
     FP2_YYY_sub(&X1,&X1,&W); FP2_YYY_norm(&X1);
     FP2_YYY_add(&X2,&X2,&W); FP2_YYY_norm(&X2);
     FP2_YYY_add(&A,&A,&A);
-    FP2_YYY_add(&A,&A,&A); 
+    FP2_YYY_add(&A,&A,&A);
     FP2_YYY_norm(&A);      // -4*g(Z)
     FP2_YYY_sqr(&T,&T);
     FP2_YYY_mul(&T,&T,&NY);
@@ -712,7 +709,7 @@ void ECP2_ZZZ_map2point(ECP2_ZZZ *Q,FP2_YYY *H)
     FP2_YYY_mul(&A,&A,&T);
     FP2_YYY_add(&X3,&X3,&A); FP2_YYY_norm(&X3);
 
-/*        
+/*
     FP_YYY_from_int(&s,-3);
     FP_YYY_sqrt(&s,&s,NULL);         // s=sqrt(-3)
     FP_YYY_sub(&j,&s,&one);     FP_YYY_norm(&j);
@@ -726,16 +723,16 @@ void ECP2_ZZZ_map2point(ECP2_ZZZ *Q,FP2_YYY *H)
     FP2_YYY_inv(&B,&B);
     FP2_YYY_mul(&B,&B,&S);      // w=s.t/(1+B+t*2)
 
-    FP2_YYY_mul(&X1,&B,&T);       
-    FP2_YYY_from_FP(&Y,&j);     
-    FP2_YYY_sub(&X2,&X1,&Y);    FP2_YYY_norm(&X2);// X2=t.w-j 
+    FP2_YYY_mul(&X1,&B,&T);
+    FP2_YYY_from_FP(&Y,&j);
+    FP2_YYY_sub(&X2,&X1,&Y);    FP2_YYY_norm(&X2);// X2=t.w-j
     FP2_YYY_neg(&X1,&X2);       FP2_YYY_norm(&X1);// X1=j-t.w
     FP2_YYY_sub(&X2,&X2,&W);    FP2_YYY_norm(&X2);
 
     FP2_YYY_sqr(&B,&B);
     FP2_YYY_inv(&B,&B);
     FP2_YYY_add(&X3,&B,&W);     FP2_YYY_norm(&X3);
- */   
+ */
 
     ECP2_ZZZ_rhs(&W,&X2);
     FP2_YYY_cmove(&X3,&X2,FP2_YYY_qr(&W));
@@ -743,11 +740,11 @@ void ECP2_ZZZ_map2point(ECP2_ZZZ *Q,FP2_YYY *H)
     FP2_YYY_cmove(&X3,&X1,FP2_YYY_qr(&W));
     ECP2_ZZZ_rhs(&W,&X3);
     FP2_YYY_sqrt(&Y,&W);
-    
+
     ne=FP2_YYY_sign(&Y)^sgn;
     FP2_YYY_neg(&W,&Y); FP2_YYY_norm(&W);
     FP2_YYY_cmove(&Y,&W,ne);
- 
+
     ECP2_ZZZ_set(Q,&X3,&Y);
 }
 
@@ -811,7 +808,6 @@ void ECP2_ZZZ_cfp(ECP2_ZZZ *Q)
     ECP2_ZZZ_frob(&T, &X);
     ECP2_ZZZ_frob(&T, &X);
     ECP2_ZZZ_add(Q, &T);
-    ECP2_ZZZ_affine(Q);
 
 #elif (PAIRING_FRIENDLY_ZZZ == BLS_CURVE)
 
@@ -839,8 +835,6 @@ void ECP2_ZZZ_cfp(ECP2_ZZZ *Q)
 
     ECP2_ZZZ_add(Q, &x2Q);
     ECP2_ZZZ_add(Q, &xQ);
-
-    ECP2_ZZZ_affine(Q);
 
 #endif
 }

--- a/cpp/ecp.cpp
+++ b/cpp/ecp.cpp
@@ -236,7 +236,7 @@ int ZZZ::ECP_set(ECP *P, BIG x)
     FP_nres(&rhs, x);
 
     ECP_rhs(&rhs, &rhs);
- 
+
     if (!FP_qr(&rhs,NULL))
     {
         ECP_inf(P);
@@ -958,7 +958,6 @@ void ZZZ::ECP_pinmul(ECP *P, int e, int bts)
         ECP_cswap(&R0, &R1, b);
     }
     ECP_copy(P, &R0);
-    ECP_affine(P);
 }
 #endif
 
@@ -981,7 +980,7 @@ void ZZZ::ECP_mul(ECP *P, BIG e)
     ECP_copy(&R1, P);
     ECP_dbl(&R1);
 
-    ECP_copy(&D, P); ECP_affine(&D);
+    ECP_copy(&D, P);
 
     nb = BIG_nbits(e);
     for (i = nb - 2; i >= 0; i--)
@@ -1062,7 +1061,6 @@ void ZZZ::ECP_mul(ECP *P, BIG e)
     }
     ECP_sub(P, &C); /* apply correction */
 #endif
-    ECP_affine(P);
 }
 
 #if CURVETYPE_ZZZ!=MONTGOMERY
@@ -1154,7 +1152,6 @@ void ZZZ::ECP_mul2(ECP *P, ECP *Q, BIG e, BIG f)
         ECP_add(P, &T);
     }
     ECP_sub(P, &C); /* apply correction */
-    ECP_affine(P);
 }
 
 #endif
@@ -1225,7 +1222,7 @@ void ZZZ::ECP_map2point(ECP *P,FP *h)
     FP X1,X2,t,one,A,w1,w2,B,Y,NY,K;
     FP_one(&one);
 
-#if MODTYPE_YYY != GENERALISED_MERSENNE  
+#if MODTYPE_YYY != GENERALISED_MERSENNE
 // its NOT goldilocks!
 // Figure out the Montgomery curve parameters
 
@@ -1243,7 +1240,7 @@ void ZZZ::ECP_map2point(ECP *P,FP *h)
     FP_norm(&A); FP_norm(&B);
 
     FP_div2(&A,&A);    // (A+B)/2     // (a+d)/2  = J/K
-    FP_div2(&B,&B);    // (B-A)/2     // (-a+d)/2 
+    FP_div2(&B,&B);    // (B-A)/2     // (-a+d)/2
     FP_div2(&B,&B);    // (B-A)/4     // (-a+d)/4 = -1/K
 
     FP_neg(&K,&B);
@@ -1278,7 +1275,7 @@ void ZZZ::ECP_map2point(ECP *P,FP *h)
 
     FP_mul(&X1,&t,&A);
     FP_neg(&X1,&X1);    // -(J/K).inv(1+z.t^2)
-    
+
     FP_copy(&X2,&X1);
     FP_add(&X2,&X2,&A); FP_norm(&X2);
     FP_neg(&X2,&X2);    // -(X1+(J/K))
@@ -1319,15 +1316,15 @@ void ZZZ::ECP_map2point(ECP *P,FP *h)
 
     if (!rfc)
     {
-        FP_mul(&X1,&X1,&K);  
-        FP_mul(&Y,&Y,&K);    
+        FP_mul(&X1,&X1,&K);
+        FP_mul(&Y,&Y,&K);
     }
     ne=sgn^FP_sign(&Y);
     FP_neg(&NY,&Y); FP_norm(&NY);
     FP_cmove(&Y,&NY,ne);
 
 
-#if MODTYPE_YYY == GENERALISED_MERSENNE  
+#if MODTYPE_YYY == GENERALISED_MERSENNE
 // GOLDILOCKS isogeny
     FP_sqr(&t,&X1);  // t=u^2
     FP_add(&NY,&t,&one); // NY=u^2+1
@@ -1345,9 +1342,9 @@ void ZZZ::ECP_map2point(ECP *P,FP *h)
     FP_norm(&Y);        // 4v^2
     FP_add(&w2,&t,&Y);  // w2=(u^2-1)^2+4v^2
     FP_norm(&w2);
-    FP_inv(&w2,&w2);    
+    FP_inv(&w2,&w2);
     FP_mul(&w1,&w1,&w2); // w1=4v(u^2-1)/[(u^2-1)^2+4v^2]
-    
+
     FP_sub(&w2,&Y,&t);   // w2=4v^2-(u^2-1)^2
     FP_norm(&w2);
     FP_mul(&w2,&w2,&X1); // w2=u(4v^2-(u^2-1)^2)
@@ -1370,7 +1367,7 @@ void ZZZ::ECP_map2point(ECP *P,FP *h)
     FP_mul(&X1,&X1,&t);
 
     if (rfc)
-        FP_mul(&X1,&X1,&K);  
+        FP_mul(&X1,&X1,&K);
 
     FP_mul(&Y,&Y,&w2);
     FP_mul(&Y,&Y,&t);
@@ -1402,14 +1399,14 @@ void ZZZ::ECP_map2point(ECP *P,FP *h)
 
         FP_imul(&t,&t,RIADZ_YYY);  // Z from hash-to-point draft standard
 
-    //    FP_norm(&t);           // t=Zt^2 
+    //    FP_norm(&t);           // t=Zt^2
         FP_add(&w,&t,&one);    // w=Zt^2+1
         FP_norm(&w);
         FP_mul(&w,&w,&t);    // w=Z^2*t^4+Zt^2
         FP_mul(&A,&A,&w);     // A=Aw
         FP_inv(&A,&A);
         FP_add(&w,&w,&one); FP_norm(&w);
-        FP_mul(&w,&w,&B);     
+        FP_mul(&w,&w,&B);
         FP_neg(&w,&w);      // -B(w+1)
         FP_norm(&w);
         FP_mul(&X2,&w,&A);   // -B(w+1)/Aw
@@ -1424,10 +1421,10 @@ void ZZZ::ECP_map2point(ECP *P,FP *h)
 // Shallue and van de Woestijne
         FP_from_int(&Y,RIADZ_YYY);
         ECP_rhs(&A,&Y);  // A=g(Z)
-        FP_sqr(&t,&t);   
+        FP_sqr(&t,&t);
         FP_mul(&Y,&A,&t);   // tv1=u^2*g(Z)
         FP_add(&t,&one,&Y); FP_norm(&t); // tv2=1+tv1
-        FP_sub(&Y,&one,&Y); FP_norm(&Y); // tv1=1-tv1 
+        FP_sub(&Y,&one,&Y); FP_norm(&Y); // tv1=1-tv1
         FP_mul(&NY,&t,&Y);
         FP_inv(&NY,&NY);     // tv3=inv0(tv1*tv2)
         FP_neg(&A,&A); FP_norm(&A);     // -g(Z)
@@ -1444,7 +1441,7 @@ void ZZZ::ECP_map2point(ECP *P,FP *h)
         FP_sub(&X1,&X1,&w); FP_norm(&X1);
         FP_add(&X2,&X2,&w); FP_norm(&X2);
         FP_add(&A,&A,&A);
-        FP_add(&A,&A,&A); 
+        FP_add(&A,&A,&A);
         FP_norm(&A);      // -4*g(Z)
         FP_sqr(&t,&t);
         FP_mul(&t,&t,&NY);
@@ -1461,14 +1458,14 @@ void ZZZ::ECP_map2point(ECP *P,FP *h)
         FP_cmove(&X3,&X1,FP_qr(&w,NULL));
         ECP_rhs(&w,&X3);
         FP_sqrt(&Y,&w,NULL);
-        FP_redc(x,&X3); 
+        FP_redc(x,&X3);
 /*
         FP_from_int(&A,-3);
         FP_sqrt(&w,&A,NULL);      // w=sqrt(-3)
         FP_sub(&j,&w,&one);  FP_norm(&j);
         FP_div2(&j,&j);        // j=(w-1)/2
         FP_mul(&w,&w,&t);     // w=s.t
-        FP_add(&B,&B,&one);   
+        FP_add(&B,&B,&one);
         FP_sqr(&Y,&t);
         FP_add(&B,&B,&Y);    // t^2+b+1
         FP_norm(&B);
@@ -1479,9 +1476,9 @@ void ZZZ::ECP_map2point(ECP *P,FP *h)
         FP_neg(&X2,&X1);
         FP_sub(&X2,&X2,&one);
         FP_norm(&X2);
-        FP_sqr(&w,&w); FP_inv(&w,&w); 
+        FP_sqr(&w,&w); FP_inv(&w,&w);
         FP_add(&X3,&w,&one); FP_norm(&X3);
-    
+
         ECP_rhs(&w,&X2);
         FP_cmove(&X1,&X2,FP_qr(&w,NULL));
         ECP_rhs(&w,&X3);
@@ -1493,7 +1490,7 @@ void ZZZ::ECP_map2point(ECP *P,FP *h)
     ne=FP_sign(&Y)^sgn;
     FP_neg(&NY,&Y); FP_norm(&NY);
     FP_cmove(&Y,&NY,ne);
- 
+
     FP_redc(y,&Y);
     ECP_set(P,x,y);
 #endif

--- a/cpp/ecp2.cpp
+++ b/cpp/ecp2.cpp
@@ -537,7 +537,6 @@ void ZZZ::ECP2_mul(ECP2 *P, BIG e)
         ECP2_add(P, &Q);
     }
     ECP2_sub(P, &C); /* apply correction */
-    ECP2_affine(P);
 }
 
 /* Calculates q.P using Frobenius constant X */
@@ -640,14 +639,12 @@ void ZZZ::ECP2_mul4(ECP2 *P, ECP2 Q[4], BIG u[4])
     ECP2_copy(&W, P);
     ECP2_sub(&W, &Q[0]);
     ECP2_cmove(P, &W, pb);
-
-    ECP2_affine(P);
 }
 
 /* Hunt and Peck a BIG to G2 curve point */
 /*
 void ZZZ::ECP2_hap2point(ECP2 *Q,BIG h)
-{ 
+{
     BIG one,hv;
     FP2 X;
     BIG_one(one);
@@ -685,10 +682,10 @@ void ZZZ::ECP2_map2point(ECP2 *Q,FP2 *H)
 
     FP2_from_ints(&Z,RIADZG2A_YYY,RIADZG2B_YYY);
     ECP2_rhs(&A,&Z);  // A=g(Z)
-    FP2_sqr(&T,&T);   
+    FP2_sqr(&T,&T);
     FP2_mul(&Y,&A,&T);   // tv1=u^2*g(Z)
     FP2_add(&T,&W,&Y); FP2_norm(&T); // tv2=1+tv1
-    FP2_sub(&Y,&W,&Y); FP2_norm(&Y); // tv1=1-tv1 
+    FP2_sub(&Y,&W,&Y); FP2_norm(&Y); // tv1=1-tv1
     FP2_mul(&NY,&T,&Y);
     FP2_inv(&NY,&NY);     // tv3=inv0(tv1*tv2)
     FP2_neg(&A,&A); FP2_norm(&A);     // -g(Z)
@@ -705,7 +702,7 @@ void ZZZ::ECP2_map2point(ECP2 *Q,FP2 *H)
     FP2_sub(&X1,&X1,&W); FP2_norm(&X1);
     FP2_add(&X2,&X2,&W); FP2_norm(&X2);
     FP2_add(&A,&A,&A);
-    FP2_add(&A,&A,&A); 
+    FP2_add(&A,&A,&A);
     FP2_norm(&A);      // -4*g(Z)
     FP2_sqr(&T,&T);
     FP2_mul(&T,&T,&NY);
@@ -731,9 +728,9 @@ void ZZZ::ECP2_map2point(ECP2 *Q,FP2 *H)
     FP2_inv(&B,&B);
     FP2_mul(&B,&B,&S);        // B=S.T/(1+B+T*2)
 
-    FP2_mul(&X1,&B,&T);       
-    FP2_from_FP(&Y,&j);     
-    FP2_sub(&X2,&X1,&Y);    FP2_norm(&X2);// X2=t.w-j 
+    FP2_mul(&X1,&B,&T);
+    FP2_from_FP(&Y,&j);
+    FP2_sub(&X2,&X1,&Y);    FP2_norm(&X2);// X2=t.w-j
     FP2_neg(&X1,&X2);       FP2_norm(&X1);// X1=j-t.w
     FP2_sub(&X2,&X2,&W);    FP2_norm(&X2);
 
@@ -749,11 +746,11 @@ void ZZZ::ECP2_map2point(ECP2 *Q,FP2 *H)
     FP2_cmove(&X3,&X1,FP2_qr(&W));
     ECP2_rhs(&W,&X3);
     FP2_sqrt(&Y,&W);
-    
+
     ne=FP2_sign(&Y)^sgn;
     FP2_neg(&W,&Y); FP2_norm(&W);
     FP2_cmove(&Y,&W,ne);
- 
+
     ECP2_set(Q,&X3,&Y);
 }
 
@@ -816,8 +813,6 @@ void ZZZ::ECP2_cfp(ECP2 *Q)
     ECP2_frob(&T, &X);
     ECP2_frob(&T, &X);
     ECP2_add(Q, &T);
-    ECP2_affine(Q);
-
 #elif (PAIRING_FRIENDLY_ZZZ == BLS_CURVE)
 
     // Efficient hash maps to G2 on BLS curves - Budroni, Pintore
@@ -844,8 +839,6 @@ void ZZZ::ECP2_cfp(ECP2 *Q)
 
     ECP2_add(Q, &x2Q);
     ECP2_add(Q, &xQ);
-
-    ECP2_affine(Q);
 
 #endif
 }

--- a/go/ECP.go
+++ b/go/ECP.go
@@ -955,7 +955,6 @@ func (E *ECP) pinmul(e int32, bts int32) *ECP {
 			R0.cswap(R1, b)
 		}
 		P.Copy(R0)
-		P.Affine()
 		return P
 	}
 }
@@ -976,7 +975,6 @@ func (E *ECP) mul(e *BIG) *ECP {
 		R1.Copy(E)
 		R1.dbl()
 		D.Copy(E)
-		D.Affine()
 		nb := e.nbits()
 		for i := nb - 2; i >= 0; i-- {
 			b := int(e.bit(i))
@@ -1045,7 +1043,6 @@ func (E *ECP) mul(e *BIG) *ECP {
 		}
 		P.Sub(C) /* apply correction */
 	}
-	P.Affine()
 	return P
 }
 
@@ -1145,7 +1142,6 @@ func (E *ECP) Mul2(e *BIG, Q *ECP, f *BIG) *ECP {
 		S.Add(T)
 	}
 	S.Sub(C) /* apply correction */
-	S.Affine()
 	return S
 }
 
@@ -1204,7 +1200,7 @@ func ECP_map2point(h *FP) *ECP {
 
             if PM1D2 == 2 {
                 t.add(t)
-            } 
+            }
             if PM1D2 == 1 {
                 t.neg();
             }
@@ -1225,7 +1221,7 @@ func ECP_map2point(h *FP) *ECP {
 
             a:=X1.redc()
             P.Copy(NewECPbig(a))
-	} 
+	}
 	if CURVETYPE == EDWARDS {
 // Elligator 2 - map to Montgomery, place point, map back
             t:=NewFPcopy(h)
@@ -1238,7 +1234,7 @@ func ECP_map2point(h *FP) *ECP {
 
 			if MODTYPE !=  GENERALISED_MERSENNE {
 				A=NewFPcopy(B)
-				
+
 				if (CURVE_A==1) {
 					A.add(one)
 					B.sub(one)
@@ -1272,7 +1268,7 @@ func ECP_map2point(h *FP) *ECP {
             t.sqr()
             if PM1D2 == 2 {
                 t.add(t)
-            } 
+            }
             if PM1D2 == 1 {
                 t.neg();
             }
@@ -1457,7 +1453,7 @@ func ECP_map2point(h *FP) *ECP {
             Y.cmove(NY,ne)
 
             y:=Y.redc()
-            P.Copy(NewECPbigs(x,y))            
+            P.Copy(NewECPbigs(x,y))
 	}
 	return P
 }

--- a/go/ECP2.go
+++ b/go/ECP2.go
@@ -551,7 +551,6 @@ func (E *ECP2) mul(e *BIG) *ECP2 {
 		P.Add(Q)
 	}
 	P.Sub(C)
-	P.Affine()
 	return P
 }
 
@@ -619,7 +618,6 @@ func (E *ECP2) Cfp() {
 		E.Add(x2Q)
 		E.Add(xQ)
 	}
-	E.Affine()
 }
 
 
@@ -712,7 +710,6 @@ func mul4(Q []*ECP2, u []*BIG) *ECP2 {
 	W.Sub(Q[0])
 	P.cmove(W, pb)
 
-	P.Affine()
 	return P
 }
 
@@ -775,7 +772,7 @@ func ECP2_hap2point(h *BIG) *ECP2 {
 	Z.sqr(); Z.imul(3); T.copy(Z)
 	T.inverse()
 	A.mul(T)
-	X3.add(A); X3.norm()	
+	X3.add(A); X3.norm()
 
 /*
     w:=s.sqrt(nil)
@@ -818,7 +815,7 @@ func ECP2_mapit(h []byte) *ECP2 {
 	q := NewBIGints(Modulus)
 	dx:=DBIG_fromBytes(h);
     x:=dx.Mod(q);
-		
+
 	Q:=ECP2_hap2point(x)
 	Q.Cfp()
     return Q

--- a/java/ECP.java
+++ b/java/ECP.java
@@ -91,7 +91,7 @@ public final class ECP {
 /* Constant time select from pre-computed table */
 	private void select(ECP W[],int b)
 	{
-		ECP MP=new ECP(); 
+		ECP MP=new ECP();
 		int m=b>>31;
 		int babs=(b^m)-m;
 
@@ -104,7 +104,7 @@ public final class ECP {
 		cmove(W[5],teq(babs,5));
 		cmove(W[6],teq(babs,6));
 		cmove(W[7],teq(babs,7));
- 
+
 		MP.copy(this);
 		MP.neg();
 		cmove(MP,(int)(m&1));
@@ -115,13 +115,13 @@ public final class ECP {
 
 		FP a=new FP();                                        // Edits made
 		FP b=new FP();
-		a.copy(x); a.mul(Q.z); 
-		b.copy(Q.x); b.mul(z); 
+		a.copy(x); a.mul(Q.z);
+		b.copy(Q.x); b.mul(z);
 		if (!a.equals(b)) return false;
 		if (CONFIG_CURVE.CURVETYPE!=CONFIG_CURVE.MONTGOMERY)
 		{
-			a.copy(y); a.mul(Q.z); 
-			b.copy(Q.y); b.mul(z); 
+			a.copy(y); a.mul(Q.z);
+			b.copy(Q.y); b.mul(z);
 			if (!a.equals(b)) return false;
 		}
 		return true;
@@ -174,7 +174,7 @@ public final class ECP {
 			r.add(b);
 		}
 		if (CONFIG_CURVE.CURVETYPE==CONFIG_CURVE.EDWARDS)
-		{ // (Ax^2-1)/(Bx^2-1) 
+		{ // (Ax^2-1)/(Bx^2-1)
 			FP b=new FP(new BIG(ROM.CURVE_B));
 
 			FP one=new FP(1);
@@ -256,7 +256,7 @@ public final class ECP {
 
 /* set to affine - from (x,y,z) to (x,y) */
 	public void affine() {
-		if (is_infinity()) return;	// 
+		if (is_infinity()) return;	//
 		FP one=new FP(1);
 		if (z.equals(one)) return;
 		z.inverse();
@@ -367,7 +367,7 @@ public final class ECP {
 	}
 /* convert to hex string */
 	public String toString() {
-		ECP W=new ECP(this);	
+		ECP W=new ECP(this);
 		W.affine();
 		if (W.is_infinity()) return "infinity";
 		if (CONFIG_CURVE.CURVETYPE==CONFIG_CURVE.MONTGOMERY) return "("+W.x.redc().toString()+")";
@@ -376,14 +376,14 @@ public final class ECP {
 
 /* convert to hex string */
 	public String toRawString() {
-		ECP W=new ECP(this);	
+		ECP W=new ECP(this);
 		if (CONFIG_CURVE.CURVETYPE==CONFIG_CURVE.MONTGOMERY) return "("+W.x.redc().toString()+","+W.z.redc().toString()+")";
 		else return "("+W.x.redc().toString()+","+W.y.redc().toString()+","+W.z.redc().toString()+")";
 	}
 
 /* this*=2 */
 	public void dbl() {
-		
+
 		if (CONFIG_CURVE.CURVETYPE==CONFIG_CURVE.WEIERSTRASS)
 		{
 			if (ROM.CURVE_A==0)
@@ -396,7 +396,7 @@ public final class ECP {
 				t2.sqr();
 
 				z.copy(t0);
-				z.add(t0); z.norm(); 
+				z.add(t0); z.norm();
 				z.add(z); z.add(z); z.norm();
 				t2.imul(3*ROM.CURVE_B_I);
 
@@ -405,12 +405,12 @@ public final class ECP {
 
 				FP y3=new FP(t0);
 				y3.add(t2); y3.norm();
-				z.mul(t1); 
+				z.mul(t1);
 				t1.copy(t2); t1.add(t2); t2.add(t1);
 				t0.sub(t2); t0.norm(); y3.mul(t0); y3.add(x3);
-				t1.copy(x); t1.mul(y); 
+				t1.copy(x); t1.mul(y);
 				x.copy(t0); x.norm(); x.mul(t1); x.add(x);
-				x.norm(); 
+				x.norm();
 				y.copy(y3); y.norm();
 			}
 			else
@@ -435,13 +435,13 @@ public final class ECP {
 				t3.add(t3); t3.norm();//5
 				z3.mul(x);   //6
 				z3.add(z3);  z3.norm();//7
-				y3.copy(t2); 
-				
+				y3.copy(t2);
+
 				if (ROM.CURVE_B_I==0)
 					y3.mul(b); //8
 				else
 					y3.imul(ROM.CURVE_B_I);
-				
+
 				y3.sub(z3); //y3.norm(); //9  ***
 				x3.copy(y3); x3.add(y3); x3.norm();//10
 
@@ -477,7 +477,7 @@ public final class ECP {
 				t1.add(t1); t1.norm();//33
 				z3.copy(t0); z3.mul(t1);//34
 
-				x.copy(x3); x.norm(); 
+				x.copy(x3); x.norm();
 				y.copy(y3); y.norm();
 				z.copy(z3); z.norm();
 			}
@@ -493,13 +493,13 @@ public final class ECP {
 			C.sqr();
 			D.sqr();
 
-			if (ROM.CURVE_A==-1) C.neg();	
+			if (ROM.CURVE_A==-1) C.neg();
 
 			y.copy(C); y.add(D); y.norm();
 			H.sqr(); H.add(H);
 
 			z.copy(y);
-			J.copy(y); 
+			J.copy(y);
 
 			J.sub(H); J.norm();
 			x.mul(J);
@@ -511,7 +511,7 @@ public final class ECP {
 		if (CONFIG_CURVE.CURVETYPE==CONFIG_CURVE.MONTGOMERY)
 		{
 			FP A=new FP(x);
-			FP B=new FP(x);		
+			FP B=new FP(x);
 			FP AA=new FP();
 			FP BB=new FP();
 			FP C=new FP();
@@ -561,7 +561,7 @@ public final class ECP {
 				t4.mul(x3);
 				x3.copy(t1);
 				x3.add(t2);
-	
+
 				t4.sub(x3); t4.norm();
 				x3.copy(x); x3.add(z); x3.norm();
 				FP y3=new FP(Q.x);
@@ -570,19 +570,19 @@ public final class ECP {
 				y3.copy(t0);
 				y3.add(t2);
 				y3.rsub(x3); y3.norm();
-				x3.copy(t0); x3.add(t0); 
+				x3.copy(t0); x3.add(t0);
 				t0.add(x3); t0.norm();
 				t2.imul(b);
 
 				FP z3=new FP(t1); z3.add(t2); z3.norm();
-				t1.sub(t2); t1.norm(); 
+				t1.sub(t2); t1.norm();
 				y3.imul(b);
-	
+
 				x3.copy(y3); x3.mul(t4); t2.copy(t3); t2.mul(t1); x3.rsub(t2);
 				y3.mul(t0); t1.mul(z3); y3.add(t1);
 				t0.mul(t3); z3.mul(t4); z3.add(t0);
 
-				x.copy(x3); x.norm(); 
+				x.copy(x3); x.norm();
 				y.copy(y3); y.norm();
 				z.copy(z3); z.norm();
 			}
@@ -623,14 +623,14 @@ public final class ECP {
 				y3.copy(t0); y3.add(t2); //y3.norm();//17
 
 				y3.rsub(x3); y3.norm(); //18
-				z3.copy(t2); 
-				
+				z3.copy(t2);
+
 
 				if (ROM.CURVE_B_I==0)
 					z3.mul(b); //18
 				else
 					z3.imul(ROM.CURVE_B_I);
-				
+
 				x3.copy(y3); x3.sub(z3); x3.norm(); //20
 				z3.copy(x3); z3.add(x3); //z3.norm(); //21
 
@@ -663,8 +663,8 @@ public final class ECP {
 				x3.sub(t1);//40
 				z3.mul(t4);//41
 				t1.copy(t3); t1.mul(t0);//42
-				z3.add(t1); 
-				x.copy(x3); x.norm(); 
+				z3.add(t1);
+				x.copy(x3); x.norm();
 				y.copy(y3); y.norm();
 				z.copy(z3); z.norm();
 			}
@@ -679,47 +679,47 @@ public final class ECP {
 			FP F=new FP();
 			FP G=new FP();
 
-			A.mul(Q.z);   
-			B.copy(A); B.sqr();    
-			C.mul(Q.x);      
-			D.mul(Q.y); 
+			A.mul(Q.z);
+			B.copy(A); B.sqr();
+			C.mul(Q.x);
+			D.mul(Q.y);
 
-			E.copy(C); E.mul(D);  
-		
+			E.copy(C); E.mul(D);
+
 			if (ROM.CURVE_B_I==0)
 			{
 				FP b=new FP(new BIG(ROM.CURVE_B));
 				E.mul(b);
 			}
 			else
-				E.imul(ROM.CURVE_B_I); 
+				E.imul(ROM.CURVE_B_I);
 
-			F.copy(B); F.sub(E);      
-			G.copy(B); G.add(E);       
+			F.copy(B); F.sub(E);
+			G.copy(B); G.add(E);
 
 			if (ROM.CURVE_A==1)
 			{
 				E.copy(D); E.sub(C);
 			}
-			C.add(D); 
+			C.add(D);
 
-			B.copy(x); B.add(y);    
-			D.copy(Q.x); D.add(Q.y); B.norm(); D.norm(); 
-			B.mul(D);                   
-			B.sub(C); B.norm(); F.norm(); 
-			B.mul(F);                     
-			x.copy(A); x.mul(B); G.norm();  
+			B.copy(x); B.add(y);
+			D.copy(Q.x); D.add(Q.y); B.norm(); D.norm();
+			B.mul(D);
+			B.sub(C); B.norm(); F.norm();
+			B.mul(F);
+			x.copy(A); x.mul(B); G.norm();
 			if (ROM.CURVE_A==1)
 			{
-				E.norm(); C.copy(E); C.mul(G);  
+				E.norm(); C.copy(E); C.mul(G);
 			}
 			if (ROM.CURVE_A==-1)
 			{
 				C.norm(); C.mul(G);
 			}
-			y.copy(A); y.mul(C);     
+			y.copy(A); y.mul(C);
 
-			z.copy(F);	
+			z.copy(F);
 			z.mul(G);
 		}
 		return;
@@ -732,10 +732,10 @@ public final class ECP {
 		FP C=new FP(Q.x);
 		FP D=new FP(Q.x);
 		FP DA=new FP();
-		FP CB=new FP();	
-			
-		A.add(z); 
-		B.sub(z); 
+		FP CB=new FP();
+
+		A.add(z);
+		B.sub(z);
 
 		C.add(Q.z);
 		D.sub(Q.z);
@@ -748,9 +748,9 @@ public final class ECP {
 		B.norm();
 		CB.copy(C); CB.mul(B);
 
-		A.copy(DA); A.add(CB); 
+		A.copy(DA); A.add(CB);
 		A.norm(); A.sqr();
-		B.copy(DA); B.sub(CB); 
+		B.copy(DA); B.sub(CB);
 		B.norm(); B.sqr();
 
 		x.copy(A);
@@ -764,7 +764,7 @@ public final class ECP {
 	}
 
 /* constant time multiply by small integer of length bts - use ladder */
-	public ECP pinmul(int e,int bts) {	
+	public ECP pinmul(int e,int bts) {
 		if (CONFIG_CURVE.CURVETYPE==CONFIG_CURVE.MONTGOMERY)
 			return this.mul(new BIG(e));
 		else
@@ -785,7 +785,6 @@ public final class ECP {
 				R0.cswap(R1,b);
 			}
 			P.copy(R0);
-			P.affine();
 			return P;
 		}
 	}
@@ -804,7 +803,7 @@ public final class ECP {
 			ECP R1=new ECP(); R1.copy(this);
 			R1.dbl();
 
-			D.copy(this); D.affine();
+			D.copy(this);
 			nb=e.nbits();
 			for (i=nb-2;i>=0;i--)
 			{
@@ -823,7 +822,7 @@ public final class ECP {
 		}
 		else
 		{
-// fixed size windows 
+// fixed size windows
 			int i,b,nb,m,s,ns;
 			BIG mt=new BIG();
 			BIG t=new BIG();
@@ -832,7 +831,7 @@ public final class ECP {
 			ECP[] W=new ECP[8];
 			byte[] w=new byte[1+(BIG.NLEN*CONFIG_BIG.BASEBITS+3)/4];
 
-// precompute table 
+// precompute table
 			Q.copy(this);
 
 			Q.dbl();
@@ -846,7 +845,7 @@ public final class ECP {
 				W[i].add(Q);
 			}
 
-// make exponent odd - add 2P if even, P if odd 
+// make exponent odd - add 2P if even, P if odd
 			t.copy(e);
 			s=t.parity();
 			t.inc(1); t.norm(); ns=t.parity(); mt.copy(t); mt.inc(1); mt.norm();
@@ -856,16 +855,16 @@ public final class ECP {
 
 			nb=1+(t.nbits()+3)/4;
 
-// convert exponent to signed 4-bit window 
+// convert exponent to signed 4-bit window
 			for (i=0;i<nb;i++)
 			{
 				w[i]=(byte)(t.lastbits(5)-16);
 				t.dec(w[i]); t.norm();
-				t.fshr(4);	
+				t.fshr(4);
 			}
 			w[nb]=(byte)t.lastbits(5);
-	
-			P.copy(W[(w[nb]-1)/2]);  
+
+			P.copy(W[(w[nb]-1)/2]);
 			for (i=nb-1;i>=0;i--)
 			{
 				Q.select(W,w[i]);
@@ -877,7 +876,6 @@ public final class ECP {
 			}
 			P.sub(C); /* apply correction */
 		}
-		P.affine();
 		return P;
 	}
 
@@ -891,14 +889,14 @@ public final class ECP {
 		ECP T=new ECP();
 		ECP C=new ECP();
 		ECP[] W=new ECP[8];
-		byte[] w=new byte[1+(BIG.NLEN*CONFIG_BIG.BASEBITS+1)/2];		
+		byte[] w=new byte[1+(BIG.NLEN*CONFIG_BIG.BASEBITS+1)/2];
 		int i,s,ns,nb;
 		byte a,b;
 
 		te.copy(e);
 		tf.copy(f);
 
-// precompute table 
+// precompute table
 		W[1]=new ECP(); W[1].copy(this); W[1].sub(Q);
 		W[2]=new ECP(); W[2].copy(this); W[2].add(Q);
 		S.copy(Q); S.dbl();
@@ -910,7 +908,7 @@ public final class ECP {
 		W[4]=new ECP(); W[4].copy(W[5]); W[4].sub(S);
 		W[7]=new ECP(); W[7].copy(W[6]); W[7].add(S);
 
-// if multiplier is odd, add 2, else add 1 to multiplier, and add 2P or P to correction 
+// if multiplier is odd, add 2, else add 1 to multiplier, and add 2P or P to correction
 
 		s=te.parity();
 		te.inc(1); te.norm(); ns=te.parity(); mt.copy(te); mt.inc(1); mt.norm();
@@ -927,19 +925,19 @@ public final class ECP {
 		mt.copy(te); mt.add(tf); mt.norm();
 		nb=1+(mt.nbits()+1)/2;
 
-// convert exponent to signed 2-bit window 
+// convert exponent to signed 2-bit window
 		for (i=0;i<nb;i++)
 		{
 			a=(byte)(te.lastbits(3)-4);
-			te.dec(a); te.norm(); 
+			te.dec(a); te.norm();
 			te.fshr(2);
 			b=(byte)(tf.lastbits(3)-4);
-			tf.dec(b); tf.norm(); 
+			tf.dec(b); tf.norm();
 			tf.fshr(2);
 			w[i]=(byte)(4*a+b);
 		}
 		w[nb]=(byte)(4*te.lastbits(3)+tf.lastbits(3));
-		S.copy(W[(w[nb]-1)/2]);  
+		S.copy(W[(w[nb]-1)/2]);
 
 		for (i=nb-1;i>=0;i--)
 		{
@@ -949,7 +947,6 @@ public final class ECP {
 			S.add(T);
 		}
 		S.sub(C); /* apply correction */
-		S.affine();
 		return S;
 	}
 
@@ -963,7 +960,7 @@ public final class ECP {
 			dbl(); dbl();
 			//affine();
 			return;
-		} 
+		}
 		if (cf==8)
 		{
 			dbl(); dbl(); dbl();
@@ -974,7 +971,7 @@ public final class ECP {
 		copy(mul(c));
 	}
 
-/* Hunt and Peck a BIG to a curve point 
+/* Hunt and Peck a BIG to a curve point
     public static ECP hap2point(BIG h)
     {
         ECP P;
@@ -984,7 +981,7 @@ public final class ECP {
 			if (CONFIG_CURVE.CURVETYPE!=CONFIG_CURVE.MONTGOMERY)
 				P=new ECP(x,0);
 			else
-				P=new ECP(x);	
+				P=new ECP(x);
 			x.inc(1); x.norm();
 			if (!P.is_infinity()) break;
 		}
@@ -1006,7 +1003,7 @@ public final class ECP {
 
             if (CONFIG_FIELD.PM1D2 == 2) {
                 t.add(t);
-            } 
+            }
             if (CONFIG_FIELD.PM1D2 == 1) {
                 t.neg();
             }
@@ -1027,7 +1024,7 @@ public final class ECP {
 
             BIG a=X1.redc();
             P=new ECP(a);
-        } 
+        }
         if (CONFIG_CURVE.CURVETYPE==CONFIG_CURVE.EDWARDS)
         { // Elligator 2 - map to Montgomery, place point, map back
             FP X1=new FP();
@@ -1054,7 +1051,7 @@ public final class ECP {
                     B.add(one);
                 }
                 A.norm(); B.norm();
- 
+
                 A.div2();
                 B.div2();
                 B.div2();
@@ -1078,7 +1075,7 @@ public final class ECP {
             t.sqr();
             if (CONFIG_FIELD.PM1D2 == 2) {
                 t.add(t);
-            }    
+            }
             if (CONFIG_FIELD.PM1D2 == 1) {
                 t.neg();
             }
@@ -1129,7 +1126,7 @@ public final class ECP {
             {
                 X1.mul(K);
                 Y.mul(K);
-            }    
+            }
             int ne=Y.sign()^sgn;
             FP NY=new FP(Y); NY.neg(); NY.norm();
             Y.cmove(NY,ne);
@@ -1175,7 +1172,7 @@ public final class ECP {
         }
 
         if (CONFIG_CURVE.CURVETYPE==CONFIG_CURVE.WEIERSTRASS)
-        { 
+        {
             FP X1=new FP();
             FP X2=new FP();
             FP X3=new FP();
@@ -1222,7 +1219,7 @@ public final class ECP {
                 t.copy(one); t.add(Y); t.norm();
                 Y.rsub(one); Y.norm();
                 NY.copy(t); NY.mul(Y); NY.inverse();
-                A.neg(); A.norm(); 
+                A.neg(); A.norm();
                 FP w=new FP(A); w.imul(3); w.copy(w.sqrt(null));
                 w.imul(Z);
                 w.mul(h); w.mul(Y); w.mul(NY);
@@ -1274,12 +1271,12 @@ public final class ECP {
             Y.cmove(NY,ne);
 
             BIG y=Y.redc();
-            P=new ECP(x,y);            
+            P=new ECP(x,y);
         }
         return P;
     }
 
-/* Map byte string to curve point 
+/* Map byte string to curve point
 	public static ECP mapit(byte[] h)
 	{
 		BIG q=new BIG(ROM.Modulus);

--- a/java/ECP2.java
+++ b/java/ECP2.java
@@ -77,7 +77,7 @@ public final class ECP2 {
 /* Constant time select from pre-computed table */
 	public void select(ECP2 W[],int b)
 	{
-		ECP2 MP=new ECP2(); 
+		ECP2 MP=new ECP2();
 		int m=b>>31;
 		int babs=(b^m)-m;
 
@@ -91,7 +91,7 @@ public final class ECP2 {
 		cmove(W[5],teq(babs,5));
 		cmove(W[6],teq(babs,6));
 		cmove(W[7],teq(babs,7));
- 
+
 		MP.copy(this);
 		MP.neg();
 		cmove(MP,(int)(m&1));
@@ -102,12 +102,12 @@ public final class ECP2 {
 
 		FP2 a=new FP2(x);                            // *****
 		FP2 b=new FP2(Q.x);
-		a.mul(Q.z); 
-		b.mul(z); 
+		a.mul(Q.z);
+		b.mul(z);
 		if (!a.equals(b)) return false;
 
-		a.copy(y); a.mul(Q.z); 
-		b.copy(Q.y); b.mul(z); 
+		a.copy(y); a.mul(Q.z);
+		b.copy(Q.y); b.mul(z);
 		if (!a.equals(b)) return false;
 
 		return true;
@@ -220,7 +220,7 @@ public final class ECP2 {
 	}
 /* convert this to hex string */
 	public String toString() {
-		ECP2 W=new ECP2(this);	
+		ECP2 W=new ECP2(this);
 		W.affine();
 		if (W.is_infinity()) return "infinity";
 		return "("+W.x.toString()+","+W.y.toString()+")";
@@ -271,7 +271,7 @@ public final class ECP2 {
 		z=new FP2(1);
 		x.norm();
 		FP2 rhs=RHS(x);
-		if (rhs.qr()==1) 
+		if (rhs.qr()==1)
 		{
             rhs.sqrt();
             if (rhs.sign() != s)
@@ -283,30 +283,30 @@ public final class ECP2 {
 	}
 
 /* this+=this */
-	public int dbl() {  
+	public int dbl() {
 		FP2 iy=new FP2(y);
 		if (CONFIG_CURVE.SEXTIC_TWIST==CONFIG_CURVE.D_TYPE)
 		{
 			iy.mul_ip(); iy.norm();
 		}
-		FP2 t0=new FP2(y);    
+		FP2 t0=new FP2(y);
 		t0.sqr();            // y^2
 		if (CONFIG_CURVE.SEXTIC_TWIST==CONFIG_CURVE.D_TYPE)
-		{		
+		{
 			t0.mul_ip();
 		}
-		FP2 t1=new FP2(iy);  
+		FP2 t1=new FP2(iy);
 		t1.mul(z);
 		FP2 t2=new FP2(z);
 		t2.sqr();			// z^2
 
 		z.copy(t0);
-		z.add(t0); z.norm(); 
-		z.add(z); 
-		z.add(z); 
-		z.norm();  
+		z.add(t0); z.norm();
+		z.add(z);
+		z.add(z);
+		z.norm();
 
-		t2.imul(3*ROM.CURVE_B_I); 
+		t2.imul(3*ROM.CURVE_B_I);
 		if (CONFIG_CURVE.SEXTIC_TWIST==CONFIG_CURVE.M_TYPE)
 		{
 			t2.mul_ip();
@@ -314,19 +314,19 @@ public final class ECP2 {
 		}
 
 		FP2 x3=new FP2(t2);
-		x3.mul(z); 
+		x3.mul(z);
 
-		FP2 y3=new FP2(t0);   
+		FP2 y3=new FP2(t0);
 
 		y3.add(t2); y3.norm();
 		z.mul(t1);
-		t1.copy(t2); t1.add(t2); t2.add(t1); t2.norm();  
+		t1.copy(t2); t1.add(t2); t2.add(t1); t2.norm();
 		t0.sub(t2); t0.norm();                           //y^2-9bz^2
 		y3.mul(t0); y3.add(x3);                          //(y^2+3z*2)(y^2-9z^2)+3b.z^2.8y^2
 		t1.copy(x); t1.mul(iy);						//
 		x.copy(t0); x.norm(); x.mul(t1); x.add(x);       //(y^2-9bz^2)xy2
 
-		x.norm(); 
+		x.norm();
 		y.copy(y3); y.norm();
 
 		return 1;
@@ -345,17 +345,17 @@ public final class ECP2 {
 		t2.mul(Q.z);
 		FP2 t3=new FP2(x);
 		t3.add(y); t3.norm();          //t3=X1+Y1
-		FP2 t4=new FP2(Q.x);            
+		FP2 t4=new FP2(Q.x);
 		t4.add(Q.y); t4.norm();			//t4=X2+Y2
 		t3.mul(t4);						//t3=(X1+Y1)(X2+Y2)
 		t4.copy(t0); t4.add(t1);		//t4=X1.X2+Y1.Y2
 
-		t3.sub(t4); t3.norm(); 
+		t3.sub(t4); t3.norm();
 		if (CONFIG_CURVE.SEXTIC_TWIST==CONFIG_CURVE.D_TYPE)
-		{		
+		{
 			t3.mul_ip();  t3.norm();         //t3=(X1+Y1)(X2+Y2)-(X1.X2+Y1.Y2) = X1.Y2+X2.Y1
 		}
-		t4.copy(y);                    
+		t4.copy(y);
 		t4.add(z); t4.norm();			//t4=Y1+Z1
 		FP2 x3=new FP2(Q.y);
 		x3.add(Q.z); x3.norm();			//x3=Y2+Z2
@@ -363,14 +363,14 @@ public final class ECP2 {
 		t4.mul(x3);						//t4=(Y1+Z1)(Y2+Z2)
 		x3.copy(t1);					//
 		x3.add(t2);						//X3=Y1.Y2+Z1.Z2
-	
-		t4.sub(x3); t4.norm(); 
+
+		t4.sub(x3); t4.norm();
 		if (CONFIG_CURVE.SEXTIC_TWIST==CONFIG_CURVE.D_TYPE)
-		{	
+		{
 			t4.mul_ip(); t4.norm();          //t4=(Y1+Z1)(Y2+Z2) - (Y1.Y2+Z1.Z2) = Y1.Z2+Y2.Z1
 		}
 		x3.copy(x); x3.add(z); x3.norm();	// x3=X1+Z1
-		FP2 y3=new FP2(Q.x);				
+		FP2 y3=new FP2(Q.x);
 		y3.add(Q.z); y3.norm();				// y3=X2+Z2
 		x3.mul(y3);							// x3=(X1+Z1)(X2+Z2)
 		y3.copy(t0);
@@ -382,26 +382,26 @@ public final class ECP2 {
 			t0.mul_ip(); t0.norm(); // x.Q.x
 			t1.mul_ip(); t1.norm(); // y.Q.y
 		}
-		x3.copy(t0); x3.add(t0); 
+		x3.copy(t0); x3.add(t0);
 		t0.add(x3); t0.norm();
-		t2.imul(b); 	
+		t2.imul(b);
 		if (CONFIG_CURVE.SEXTIC_TWIST==CONFIG_CURVE.M_TYPE)
 		{
 			t2.mul_ip(); t2.norm();
 		}
 		FP2 z3=new FP2(t1); z3.add(t2); z3.norm();
-		t1.sub(t2); t1.norm(); 
-		y3.imul(b); 
+		t1.sub(t2); t1.norm();
+		y3.imul(b);
 		if (CONFIG_CURVE.SEXTIC_TWIST==CONFIG_CURVE.M_TYPE)
 		{
-			y3.mul_ip(); 
+			y3.mul_ip();
 			y3.norm();
 		}
 		x3.copy(y3); x3.mul(t4); t2.copy(t3); t2.mul(t1); x3.rsub(t2);
 		y3.mul(t0); t1.mul(z3); y3.add(t1);
 		t0.mul(t3); z3.mul(t4); z3.add(t0);
 
-		x.copy(x3); x.norm(); 
+		x.copy(x3); x.norm();
 		y.copy(y3); y.norm();
 		z.copy(z3); z.norm();
 
@@ -473,11 +473,11 @@ public final class ECP2 {
 		{
 			w[i]=(byte)(t.lastbits(5)-16);
 			t.dec(w[i]); t.norm();
-			t.fshr(4);	
+			t.fshr(4);
 		}
 		w[nb]=(byte)t.lastbits(5);
-	
-		P.copy(W[(w[nb]-1)/2]);  
+
+		P.copy(W[(w[nb]-1)/2]);
 		for (i=nb-1;i>=0;i--)
 		{
 			Q.select(W,w[i]);
@@ -488,14 +488,13 @@ public final class ECP2 {
 			P.add(Q);
 		}
 		P.sub(C);
-		P.affine();
 		return P;
 	}
 
 /* P=u0.Q0+u1*Q1+u2*Q2+u3*Q3 */
 // Bos & Costello https://eprint.iacr.org/2013/458.pdf
 // Faz-Hernandez & Longa & Sanchez  https://eprint.iacr.org/2013/158.pdf
-// Side channel attack secure 
+// Side channel attack secure
 
 	public static ECP2 mul4(ECP2[] Q,BIG[] u)
 	{
@@ -534,11 +533,11 @@ public final class ECP2 {
     // Number of bits
         mt.zero();
         for (i=0;i<4;i++) {
-            mt.or(t[i]); 
+            mt.or(t[i]);
         }
         nb=1+mt.nbits();
 
-    // Sign pivot 
+    // Sign pivot
         s[nb-1]=1;
         for (i=0;i<nb-1;i++) {
             t[0].fshr(1);
@@ -557,10 +556,10 @@ public final class ECP2 {
                 w[i]+=bt*(byte)k;
                 k*=2;
             }
-        } 
+        }
 
     // Main loop
-        P.select(T,(int)(2*w[nb-1]+1));  
+        P.select(T,(int)(2*w[nb-1]+1));
         for (i=nb-2;i>=0;i--) {
             P.dbl();
             W.select(T,(int)(2*w[i]+s[i]));
@@ -568,16 +567,15 @@ public final class ECP2 {
         }
 
     // apply correction
-        W.copy(P);   
+        W.copy(P);
         W.sub(Q[0]);
-        P.cmove(W,pb);   
-		P.affine();
+        P.cmove(W,pb);
 		return P;
-	}        
+	}
 
 /* Hunt and Peck a BIG to a curve point
     public static ECP2 hap2point(BIG h)
-    { 
+    {
         BIG x=new BIG(h);
 		BIG one=new BIG(1);
 		FP2 X2;
@@ -594,7 +592,7 @@ public final class ECP2 {
 
 /* Constant time Map to Point */
     public static ECP2 map2point(FP2 H)
-    { 
+    {
     // Shallue and van de Woestijne method.
         int sgn,ne;
         FP2 W=new FP2(1);
@@ -615,7 +613,7 @@ public final class ECP2 {
         T.copy(W); T.add(Y); T.norm();
         Y.rsub(W); Y.norm();
         FP2 NY=new FP2(T); NY.mul(Y); NY.inverse();
-        A.neg(); A.norm(); 
+        A.neg(); A.norm();
         W.copy(A); W.imul(3); W.sqrt();
         W.mul(Z);
         W.mul(H); W.mul(Y); W.mul(NY);
@@ -670,13 +668,13 @@ public final class ECP2 {
         return new ECP2(X3,Y);
     }
 
-/* Map octet string to curve point 
+/* Map octet string to curve point
 	public static ECP2 mapit(byte[] h)
 	{
 		BIG q=new BIG(ROM.Modulus);
 		DBIG dx=DBIG.fromBytes(h);
         BIG x=dx.mod(q);
-		
+
 		ECP2 Q=hap2point(x);
 		Q.cfp();
         return Q;
@@ -704,12 +702,12 @@ public final class ECP2 {
 			ECP2 T,K;
 
 			T=new ECP2(); T.copy(this);
-			T=T.mul(x); 
-			
+			T=T.mul(x);
+
 			if (CONFIG_CURVE.SIGN_OF_X==CONFIG_CURVE.NEGATIVEX)
 			{
 				T.neg();
-			}	
+			}
 			K=new ECP2(); K.copy(T);
 			K.dbl(); K.add(T); //K.affine();
 
@@ -732,7 +730,7 @@ public final class ECP2 {
 			if (CONFIG_CURVE.SIGN_OF_X==CONFIG_CURVE.NEGATIVEX)
 			{
 				xQ.neg();
-			}	
+			}
 
 			x2Q.sub(xQ);
 			x2Q.sub(this);
@@ -747,7 +745,6 @@ public final class ECP2 {
 			add(x2Q);
 			add(xQ);
 		}
-		affine();
 	}
 
 	public static ECP2 generator()

--- a/javascript/ecp.js
+++ b/javascript/ecp.js
@@ -198,7 +198,7 @@ var ECP = function(ctx) {
                 if (rhs.qr(null) != 1) {
                     this.inf();
                 }
- 
+
             } else {
                 y2 = new ctx.FP(0);
                 y2.copy(this.y);
@@ -377,13 +377,13 @@ var ECP = function(ctx) {
 
                 if (ctx.ROM_CURVE.CURVE_A == 0) {
                     t0 = new ctx.FP(0);
-                    t0.copy(this.y);                    
+                    t0.copy(this.y);
                     t0.sqr();
                     t1 = new ctx.FP(0);
-                    t1.copy(this.y); 
+                    t1.copy(this.y);
                     t1.mul(this.z);
                     t2 = new ctx.FP(0);
-                    t2.copy(this.z); 
+                    t2.copy(this.z);
                     t2.sqr();
 
                     this.z.copy(t0);
@@ -396,10 +396,10 @@ var ECP = function(ctx) {
                     t2.imul(3 * ctx.ROM_CURVE.CURVE_B_I);
 
                     x3 = new ctx.FP(0);
-                    x3.copy(t2); 
+                    x3.copy(t2);
                     x3.mul(this.z);
                     y3 = new ctx.FP(0);
-                    y3.copy(t0); 
+                    y3.copy(t0);
                     y3.add(t2);
                     y3.norm();
                     this.z.mul(t1);
@@ -422,23 +422,23 @@ var ECP = function(ctx) {
                     this.y.norm();
                 } else {
                     t0 = new ctx.FP(0);
-                    t0.copy(this.x); 
+                    t0.copy(this.x);
                     t1 = new ctx.FP(0);
-                    t1.copy(this.y); 
+                    t1.copy(this.y);
                     t2 = new ctx.FP(0);
-                    t2.copy(this.z); 
+                    t2.copy(this.z);
                     t3 = new ctx.FP(0);
-                    t3.copy(this.x); 
+                    t3.copy(this.x);
                     z3 = new ctx.FP(0);
-                    z3.copy(this.z); 
-                    y3 = new ctx.FP(0); 
-                    x3 = new ctx.FP(0); 
-                    b = new ctx.FP(0); 
-                    
+                    z3.copy(this.z);
+                    y3 = new ctx.FP(0);
+                    x3 = new ctx.FP(0);
+                    b = new ctx.FP(0);
+
                     if (ctx.ROM_CURVE.CURVE_B_I == 0) {
                         b.rcopy(ctx.ROM_CURVE.CURVE_B);
                     }
-                   
+
                     t0.sqr(); //1    x^2
                     t1.sqr(); //2    y^2
                     t2.sqr(); //3
@@ -508,7 +508,7 @@ var ECP = function(ctx) {
                     t1.norm(); //33
                     z3.copy(t0);
                     z3.mul(t1); //34
-                  
+
                     this.x.copy(x3);
                     this.x.norm();
                     this.y.copy(y3);
@@ -520,13 +520,13 @@ var ECP = function(ctx) {
 
             if (ECP.CURVETYPE == ECP.EDWARDS) {
                 C = new ctx.FP(0);
-                C.copy(this.x); 
+                C.copy(this.x);
                 D = new ctx.FP(0);
-                D.copy(this.y); 
+                D.copy(this.y);
                 H = new ctx.FP(0);
-                H.copy(this.z); 
-                J = new ctx.FP(0); 
-               
+                H.copy(this.z);
+                J = new ctx.FP(0);
+
                 this.x.mul(this.y);
                 this.x.add(this.x);
                 this.x.norm();
@@ -557,12 +557,12 @@ var ECP = function(ctx) {
 
             if (ECP.CURVETYPE == ECP.MONTGOMERY) {
                 A = new ctx.FP(0);
-                A.copy(this.x); 
+                A.copy(this.x);
                 B = new ctx.FP(0);
-                B.copy(this.x); 
-                AA = new ctx.FP(0); 
-                BB = new ctx.FP(0); 
-                C = new ctx.FP(0); 
+                B.copy(this.x);
+                AA = new ctx.FP(0);
+                BB = new ctx.FP(0);
+                C = new ctx.FP(0);
 
                 A.add(this.z);
                 A.norm();
@@ -600,20 +600,20 @@ var ECP = function(ctx) {
 
                     b = 3 * ctx.ROM_CURVE.CURVE_B_I;
                     t0 = new ctx.FP(0);
-                    t0.copy(this.x); 
+                    t0.copy(this.x);
                     t0.mul(Q.x);
                     t1 = new ctx.FP(0);
-                    t1.copy(this.y); 
+                    t1.copy(this.y);
                     t1.mul(Q.y);
                     t2 = new ctx.FP(0);
-                    t2.copy(this.z); 
+                    t2.copy(this.z);
                     t2.mul(Q.z);
                     t3 = new ctx.FP(0);
-                    t3.copy(this.x); 
+                    t3.copy(this.x);
                     t3.add(this.y);
                     t3.norm();
                     t4 = new ctx.FP(0);
-                    t4.copy(Q.x); 
+                    t4.copy(Q.x);
                     t4.add(Q.y);
                     t4.norm();
                     t3.mul(t4);
@@ -626,7 +626,7 @@ var ECP = function(ctx) {
                     t4.add(this.z);
                     t4.norm();
                     x3 = new ctx.FP(0);
-                    x3.copy(Q.y); 
+                    x3.copy(Q.y);
                     x3.add(Q.z);
                     x3.norm();
 
@@ -640,7 +640,7 @@ var ECP = function(ctx) {
                     x3.add(this.z);
                     x3.norm();
                     y3 = new ctx.FP(0);
-                    y3.copy(Q.x); 
+                    y3.copy(Q.x);
                     y3.add(Q.z);
                     y3.norm();
                     x3.mul(y3);
@@ -655,7 +655,7 @@ var ECP = function(ctx) {
                     t2.imul(b);
 
                     z3 = new ctx.FP(0);
-                    z3.copy(t1); 
+                    z3.copy(t1);
                     z3.add(t2);
                     z3.norm();
                     t1.sub(t2);
@@ -682,21 +682,21 @@ var ECP = function(ctx) {
                     this.z.norm();
                 } else {
                     t0 = new ctx.FP(0);
-                    t0.copy(this.x); 
+                    t0.copy(this.x);
                     t1 = new ctx.FP(0);
-                    t1.copy(this.y); 
+                    t1.copy(this.y);
                     t2 = new ctx.FP(0);
-                    t2.copy(this.z); 
+                    t2.copy(this.z);
                     t3 = new ctx.FP(0);
-                    t3.copy(this.x); 
+                    t3.copy(this.x);
                     t4 = new ctx.FP(0);
-                    t4.copy(Q.x); 
-                    z3 = new ctx.FP(0); 
+                    t4.copy(Q.x);
+                    z3 = new ctx.FP(0);
                     y3 = new ctx.FP(0);
-                    y3.copy(Q.x); 
+                    y3.copy(Q.x);
                     x3 = new ctx.FP(0);
-                    x3.copy(Q.y); 
-                    b = new ctx.FP(0); 
+                    x3.copy(Q.y);
+                    b = new ctx.FP(0);
 
                     if (ctx.ROM_CURVE.CURVE_B_I == 0) {
                         b.rcopy(ctx.ROM_CURVE.CURVE_B);
@@ -794,8 +794,8 @@ var ECP = function(ctx) {
                     z3.mul(t4); //41
                     t1.copy(t3);
                     t1.mul(t0); //42
-                    z3.add(t1); 
-           
+                    z3.add(t1);
+
                     this.x.copy(x3);
                     this.x.norm();
                     this.y.copy(y3);
@@ -807,15 +807,15 @@ var ECP = function(ctx) {
 
             if (ECP.CURVETYPE == ECP.EDWARDS) {
                 A = new ctx.FP(0);
-                A.copy(this.z); 
-                B = new ctx.FP(0); 
+                A.copy(this.z);
+                B = new ctx.FP(0);
                 C = new ctx.FP(0);
-                C.copy(this.x); 
+                C.copy(this.x);
                 D = new ctx.FP(0);
-                D.copy(this.y); 
-                E = new ctx.FP(0); 
-                F = new ctx.FP(0); 
-                G = new ctx.FP(0); 
+                D.copy(this.y);
+                E = new ctx.FP(0);
+                F = new ctx.FP(0);
+                G = new ctx.FP(0);
 
                 A.mul(Q.z); //A=2
                 B.copy(A);
@@ -956,7 +956,6 @@ var ECP = function(ctx) {
                 }
 
                 P.copy(R0);
-                P.affine();
 
                 return P;
             }
@@ -1002,7 +1001,6 @@ var ECP = function(ctx) {
                 R1.copy(this);
                 R1.dbl();
                 D.copy(this);
-                D.affine();
                 nb = e.nbits();
                 for (i = nb - 2; i >= 0; i--) {
                     b = e.bit(i);
@@ -1071,8 +1069,6 @@ var ECP = function(ctx) {
                 }
                 P.sub(C);
             }
-
-            P.affine();
 
             return P;
         },
@@ -1175,7 +1171,6 @@ var ECP = function(ctx) {
                 S.add(T);
             }
             S.sub(C); /* apply correction */
-            S.affine();
 
             return S;
         }
@@ -1310,7 +1305,7 @@ var ECP = function(ctx) {
         return r;
     };
 
-/* Hunt and Peck a BIG to a curve point 
+/* Hunt and Peck a BIG to a curve point
     ECP.hap2point = function(h) {
         var P = new ECP();
         var x=new ctx.BIG(h);
@@ -1342,7 +1337,7 @@ var ECP = function(ctx) {
 
             if (ctx.FP.PM1D2 == 2) {
                 t.add(t);
-            } 
+            }
             if (ctx.FP.PM1D2 == 1) {
                 t.neg();
             }
@@ -1363,7 +1358,7 @@ var ECP = function(ctx) {
 
             var a=X1.redc();
             P.setx(a);
-        } 
+        }
         if (ECP.CURVETYPE == ECP.EDWARDS)
         { // Elligator 2 - map to Montgomery, place point, map back
             var X1=new ctx.FP(0);
@@ -1411,11 +1406,11 @@ var ECP = function(ctx) {
                 A=new ctx.FP(156326);
                 rfc=1;
             }
-            
+
             t.sqr();
             if (ctx.FP.PM1D2 == 2) {
                 t.add(t);
-            } 
+            }
             if (ctx.FP.PM1D2 == 1) {
                 t.neg();
             }
@@ -1466,7 +1461,7 @@ var ECP = function(ctx) {
             {
                 X1.mul(K);
                 Y.mul(K);
-            }    
+            }
             var ne=Y.sign()^sgn;
             var NY=new ctx.FP(Y); NY.neg(); NY.norm();
             Y.cmove(NY,ne);
@@ -1488,7 +1483,7 @@ var ECP = function(ctx) {
                 t.mul(X1);
                 X1.copy(w1);
                 Y.div2();
-                w1.copy(Y); w1.mul(NY); 
+                w1.copy(Y); w1.mul(NY);
                 w1.rsub(t); w1.norm();
                 w1.inverse();
                 Y.copy(w2); Y.mul(w1);
@@ -1508,7 +1503,7 @@ var ECP = function(ctx) {
             var x=X1.redc();
             var y=Y.redc();
             P.setxy(x,y);
-            
+
         }
         if (ECP.CURVETYPE == ECP.WEIERSTRASS)
         { // swu method
@@ -1560,7 +1555,7 @@ var ECP = function(ctx) {
                 t.copy(one); t.add(Y); t.norm();
                 Y.rsub(one); Y.norm();
                 NY.copy(t); NY.mul(Y); NY.inverse();
-                A.neg(); A.norm(); 
+                A.neg(); A.norm();
                 var w=new ctx.FP(A); w.imul(3); w.copy(w.sqrt(null));
                 w.imul(Z);
                 w.mul(h); w.mul(Y); w.mul(NY);
@@ -1612,8 +1607,8 @@ var ECP = function(ctx) {
             Y.cmove(NY,ne);
 
             var y=Y.redc();
-            P.setxy(x,y);          
-          
+            P.setxy(x,y);
+
         }
         return P;
     };

--- a/javascript/ecp2.js
+++ b/javascript/ecp2.js
@@ -202,7 +202,7 @@ var ECP2 = function(ctx) {
                 b[0]=0x02;
                 if (W.y.sign() == 1)
                     b[0]=0x03;
-            }            
+            }
         },
 
         /* convert this to hex string */
@@ -226,7 +226,7 @@ var ECP2 = function(ctx) {
 
             rhs = ECP2.RHS(this.x);
 
-            y2 = new ctx.FP2(this.y); 
+            y2 = new ctx.FP2(this.y);
             y2.sqr();
 
             if (!y2.equals(rhs)) {
@@ -244,7 +244,7 @@ var ECP2 = function(ctx) {
 
             rhs = ECP2.RHS(this.x);
 //alert("Into setx= rhs= "+rhs.toString());
-		    if (rhs.qr()==1) 
+		    if (rhs.qr()==1)
 		    {
                 rhs.sqrt();
                 if (rhs.sign() != s)
@@ -276,20 +276,20 @@ var ECP2 = function(ctx) {
             var iy, t0, t1, t2, x3, y3;
 
             iy = new ctx.FP2(0);
-            iy.copy(this.y); 
+            iy.copy(this.y);
             if (ctx.ECP.SEXTIC_TWIST == ctx.ECP.D_TYPE) {
                 iy.mul_ip();
                 iy.norm();
             }
 
             t0 = new ctx.FP2(0);
-            t0.copy(this.y); 
+            t0.copy(this.y);
             t0.sqr();
             if (ctx.ECP.SEXTIC_TWIST == ctx.ECP.D_TYPE) {
                 t0.mul_ip();
             }
             t1 = new ctx.FP2(0);
-            t1.copy(iy); 
+            t1.copy(iy);
             t1.mul(this.z);
             t2 = new ctx.FP2(0);
             t2.copy(this.z);
@@ -309,11 +309,11 @@ var ECP2 = function(ctx) {
             }
 
             x3 = new ctx.FP2(0);
-            x3.copy(t2); 
+            x3.copy(t2);
             x3.mul(this.z);
 
             y3 = new ctx.FP2(0);
-            y3.copy(t0); 
+            y3.copy(t0);
 
             y3.add(t2);
             y3.norm();
@@ -347,21 +347,21 @@ var ECP2 = function(ctx) {
 
             b = 3 * ctx.ROM_CURVE.CURVE_B_I;
             t0 = new ctx.FP2(0);
-            t0.copy(this.x); 
+            t0.copy(this.x);
             t0.mul(Q.x); // x.Q.x
             t1 = new ctx.FP2(0);
-            t1.copy(this.y); 
+            t1.copy(this.y);
             t1.mul(Q.y); // y.Q.y
 
             t2 = new ctx.FP2(0);
-            t2.copy(this.z); 
+            t2.copy(this.z);
             t2.mul(Q.z);
             t3 = new ctx.FP2(0);
-            t3.copy(this.x); 
+            t3.copy(this.x);
             t3.add(this.y);
             t3.norm(); //t3=X1+Y1
             t4 = new ctx.FP2(0);
-            t4.copy(Q.x); 
+            t4.copy(Q.x);
             t4.add(Q.y);
             t4.norm(); //t4=X2+Y2
             t3.mul(t4); //t3=(X1+Y1)(X2+Y2)
@@ -379,7 +379,7 @@ var ECP2 = function(ctx) {
             t4.add(this.z);
             t4.norm(); //t4=Y1+Z1
             x3 = new ctx.FP2(0);
-            x3.copy(Q.y); 
+            x3.copy(Q.y);
             x3.add(Q.z);
             x3.norm(); //x3=Y2+Z2
 
@@ -398,7 +398,7 @@ var ECP2 = function(ctx) {
             x3.add(this.z);
             x3.norm(); // x3=X1+Z1
             y3 = new ctx.FP2(0);
-            y3.copy(Q.x); 
+            y3.copy(Q.x);
             y3.add(Q.z);
             y3.norm(); // y3=X2+Z2
             x3.mul(y3); // x3=(X1+Z1)(X2+Z2)
@@ -424,7 +424,7 @@ var ECP2 = function(ctx) {
             }
 
             z3 = new ctx.FP2(0);
-            z3.copy(t1); 
+            z3.copy(t1);
             z3.add(t2);
             z3.norm();
             t1.sub(t2);
@@ -528,7 +528,6 @@ var ECP2 = function(ctx) {
                 P.add(Q);
             }
             P.sub(C);
-            P.affine();
 
             return P;
         },
@@ -539,7 +538,7 @@ var ECP2 = function(ctx) {
                 fb = new ctx.BIG(0),
                 q, x, T, K, X, xQ, x2Q;
 
-        // Fast Hashing to G2 - Fuentes-Castaneda, Knapp and Rodriguez-Henriquez 
+        // Fast Hashing to G2 - Fuentes-Castaneda, Knapp and Rodriguez-Henriquez
             fa.rcopy(ctx.ROM_FIELD.Fra);
             fb.rcopy(ctx.ROM_FIELD.Frb);
             X = new ctx.FP2(fa, fb);
@@ -596,8 +595,6 @@ var ECP2 = function(ctx) {
                 this.add(x2Q);
                 this.add(xQ);
             }
-
-            this.affine();
         }
 
     };
@@ -654,7 +651,7 @@ var ECP2 = function(ctx) {
             P.setxy(rx, ry);
         } else {
             P.setx(rx,typ&1);
-        }   
+        }
         return P;
     };
 
@@ -761,7 +758,6 @@ var ECP2 = function(ctx) {
         W.copy(P);
         W.sub(Q[0]);
         P.cmove(W,pb);
-        P.affine();
         return P;
     };
 
@@ -775,7 +771,7 @@ var ECP2 = function(ctx) {
 
 /* Hunt and Peck a BIG to a curve point
     ECP2.hap2point = function(h)
-    { 
+    {
         var one=new ctx.BIG(1);
         var x=new ctx.BIG(h);
         var Q,X2;
@@ -792,7 +788,7 @@ var ECP2 = function(ctx) {
 
 /* Constant time Map to Point */
     ECP2.map2point = function(H)
-    { 
+    {
     // Shallue and van de Woestijne method.
         var sgn,ne;
         var W=new ctx.FP2(1);
@@ -820,7 +816,7 @@ var ECP2 = function(ctx) {
         T.copy(W); T.add(Y); T.norm();
         Y.rsub(W); Y.norm();
         var NY=new ctx.FP2(T); NY.mul(Y); NY.inverse();
-        A.neg(); A.norm(); 
+        A.neg(); A.norm();
         W.copy(A); W.imul(3); W.sqrt();
         W.mul(Z);
         W.mul(H); W.mul(Y); W.mul(NY);
@@ -874,14 +870,14 @@ var ECP2 = function(ctx) {
         return P;
     };
 
-/* Map octet string to curve point 
+/* Map octet string to curve point
 	ECP2.mapit = function(h)
 	{
 		var q=new ctx.BIG(0);
         q.rcopy(ctx.ROM_FIELD.Modulus);
 		var dx=ctx.DBIG.fromBytes(h);
         var x=dx.mod(q);
-		
+
 		var Q=ECP2.hap2point(x);
 		Q.cfp();
         return Q;

--- a/python/ecp.py
+++ b/python/ecp.py
@@ -39,11 +39,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-#   You can be released from the requirements of the license by purchasing     
+#   You can be released from the requirements of the license by purchasing
 #   a commercial license. Buying such a license is mandatory as soon as you
 #   develop commercial activities involving the MIRACL Core Crypto SDK
 #   without disclosing the source code of your own applications, or shipping
-#   the MIRACL Core Crypto SDK with a closed source product.     
+#   the MIRACL Core Crypto SDK with a closed source product.
 
 #
 # Elliptic Curve Points
@@ -531,7 +531,6 @@ class ECp:
             R1.dbl()
 
             D = self.copy()
-            D.affine()
             nb = e.bit_length()
             # nb=curve.r.bit_length()
             for i in range(nb - 2, -1, -1):
@@ -560,7 +559,6 @@ class ECp:
                     R.add(self)
                 if big.bit(b3, i) == 0 and big.bit(b, i) == 1:
                     R.add(mself)
-        R.affine()
         return R
 
     def mul(P, a, Q, b):  # double multiplication a*P+b*Q

--- a/rust/ecp.rs
+++ b/rust/ecp.rs
@@ -24,6 +24,7 @@ use crate::xxx::fp::FP;
 use crate::xxx::fp;
 use crate::xxx::rom;
 
+#[derive(Clone)]
 pub struct ECP {
     x: FP,
     y: FP,
@@ -379,7 +380,7 @@ impl ECP {
             //b[0] = 0x06;
             return;
         }
-        
+
         for i in 0..mb {
             b[i + 1] = t[i]
         }
@@ -979,7 +980,6 @@ impl ECP {
                 R0.cswap(&mut R1, b);
             }
             P.copy(&R0);
-            P.affine();
             return P;
         }
     }
@@ -1000,7 +1000,6 @@ impl ECP {
             R1.copy(&self);
             R1.dbl();
             D.copy(&self);
-            D.affine();
             let nb = e.nbits();
 
             for i in (0..nb - 1).rev() {
@@ -1080,7 +1079,6 @@ impl ECP {
             }
             P.sub(&mut C); /* apply correction */
         }
-        P.affine();
         return P;
     }
 
@@ -1191,7 +1189,6 @@ impl ECP {
             S.add(&mut T);
         }
         S.sub(&mut C); /* apply correction */
-        S.affine();
         return S;
     }
 
@@ -1253,7 +1250,7 @@ impl ECP {
 
             if fp::PM1D2 == 2 {
                 t.dbl();
-            } 
+            }
             if fp::PM1D2 == 1 {
                 t.neg();
             }
@@ -1275,7 +1272,7 @@ impl ECP {
             let a=X1.redc();
             P.copy(&ECP::new_big(&a));
 
-        } 
+        }
         if CURVETYPE == EDWARDS {
 // Elligator 2 - map to Montgomery, place point, map back
             let mut X1=FP::new();
@@ -1323,7 +1320,7 @@ impl ECP {
             t.sqr();
             if fp::PM1D2 == 2 {
                 t.dbl();
-            } 
+            }
             if fp::PM1D2 == 1 {
                 t.neg();
             }
@@ -1513,8 +1510,8 @@ impl ECP {
             Y.cmove(&NY,ne);
 
             let y=Y.redc();
-            P.copy(&ECP::new_bigs(&x,&y));         
-        } 
+            P.copy(&ECP::new_bigs(&x,&y));
+        }
         return P;
     }
 

--- a/rust/ecp2.rs
+++ b/rust/ecp2.rs
@@ -26,7 +26,7 @@ use crate::xxx::fp;
 //use crate::xxx::fp::FP;
 use crate::xxx::dbig::DBIG;
 
-//#[derive(Copy, Clone)]
+#[derive(Clone)]
 pub struct ECP2 {
     x: FP2,
     y: FP2,
@@ -567,7 +567,6 @@ impl ECP2 {
             P.add(&mut Q);
         }
         P.sub(&mut C);
-        P.affine();
         return P;
     }
 
@@ -620,8 +619,6 @@ impl ECP2 {
             self.add(&x2Q);
             self.add(&xQ);
         }
-
-        self.affine();
     }
 
 
@@ -731,7 +728,6 @@ impl ECP2 {
         W.copy(&P);
         W.sub(&mut Q[0]);
         P.cmove(&W, pb);
-        P.affine();
 
         return P;
     }

--- a/swift/ecp.swift
+++ b/swift/ecp.swift
@@ -797,7 +797,6 @@ public struct ECP {
 				R0.cswap(&R1,b);
             }
             P.copy(R0);
-            P.affine();
             return P;
         }
     }
@@ -816,7 +815,7 @@ public struct ECP {
             var R0=ECP(); R0.copy(self)
             var R1=ECP(); R1.copy(self)
             R1.dbl();
-            D.copy(self); D.affine();
+            D.copy(self);
             let nb=e.nbits();
 
             for i in (0...nb-2).reversed()
@@ -889,7 +888,6 @@ public struct ECP {
             }
             P.sub(C); /* apply correction */
         }
-        P.affine();
         return P;
     }
 
@@ -962,7 +960,6 @@ public struct ECP {
             S.add(T);
         }
         S.sub(C); /* apply correction */
-        S.affine();
         return S;
     }
 

--- a/swift/ecp2.swift
+++ b/swift/ecp2.swift
@@ -471,7 +471,6 @@ public struct ECP2 {
             P.add(Q)
         }
         P.sub(C);
-        P.affine()
         return P;
     }
 
@@ -524,7 +523,6 @@ public struct ECP2 {
             self.add(x2Q)
             self.add(xQ)
         }
-        self.affine()
     }
 
 
@@ -610,7 +608,6 @@ public struct ECP2 {
         W.copy(P)
         W.sub(Q[0])
         P.cmove(W,pb)
-        P.affine()
         return P
     }
 


### PR DESCRIPTION
Avoid converting ECP and ECP2 to affine coordinates unless the result needs to be converted to bytes or string.

Signed-off-by: lovesh <lovesh.bond@gmail.com>