### PR TITLE
enable "frombytearray" to work with inputs of lesser size than int(MODBYTES)

### DIFF
--- a/go/BIG32.go
+++ b/go/BIG32.go
@@ -525,9 +525,14 @@ func (r *BIG) tobytearray(b []byte, n int) {
 /* convert from byte array to BIG */
 func frombytearray(b []byte, n int) *BIG {
 	m := NewBIG()
+	l := len(b)
 	for i := 0; i < int(MODBYTES); i++ {
 		m.fshl(8)
-		m.w[0] += Chunk(int(b[i+n] & 0xff))
+		if i < l {
+			m.w[0] += Chunk(int(b[i+n] & 0xff))
+		} else {
+			m.w[0] += Chunk(int(0 & 0xff))
+		}
 	}
 	return m
 }

--- a/go/BIG64.go
+++ b/go/BIG64.go
@@ -467,9 +467,14 @@ func (r *BIG) tobytearray(b []byte, n int) {
 /* convert from byte array to BIG */
 func frombytearray(b []byte, n int) *BIG {
 	m := NewBIG()
+	l := len(b)
 	for i := 0; i < int(MODBYTES); i++ {
 		m.fshl(8)
-		m.w[0] += Chunk(int(b[i+n] & 0xff))
+		if i < l {
+			m.w[0] += Chunk(int(b[i+n] & 0xff))
+		} else {
+			m.w[0] += Chunk(int(0 & 0xff))
+		}
 	}
 	return m
 }


### PR DESCRIPTION
The current implementation of "frombytearray" (which is called by "FromBytes") expects that the input byte array 'b' to be of specific length "int(MODBYTES)". If we try to use any byte array with lesser size as input, we get "index out of range" error.

I realized this inflexibility in the context of idemix testing (github.com/hyperledger/fabric/idemix) and the fix helped to test idemix with arbitrary attribute values such as "bob", "123" and so on. Thanks.