### PR TITLE
rust: remove unneeded `mut` modifiers.

### DIFF
--- a/rust/big.rs
+++ b/rust/big.rs
@@ -373,7 +373,7 @@ impl BIG {
     }
 
     /* convert this BIG to byte array */
-    pub fn tobytearray(&mut self, b: &mut [u8], n: usize) {
+    pub fn tobytearray(&self, b: &mut [u8], n: usize) {
         let mut c = BIG::new_copy(self);
         c.norm();
 
@@ -393,7 +393,7 @@ impl BIG {
         return m;
     }
 
-    pub fn tobytes(&mut self, b: &mut [u8]) {
+    pub fn tobytes(&self, b: &mut [u8]) {
         self.tobytearray(b, 0)
     }
 

--- a/rust/bls.rs
+++ b/rust/bls.rs
@@ -120,7 +120,7 @@ pub fn key_pair_generate(ikm: &[u8], s: &mut [u8], w: &mut [u8]) -> isize {
     hmac::hkdf_expand(hmac::MC_SHA2,hlen,&mut okm,el,&prk[0 .. hlen],&len);
 
     let mut dx = DBIG::frombytes(&okm[0 .. el]);
-    let mut sc = dx.dmod(&r);
+    let sc = dx.dmod(&r);
     sc.tobytes(s);
 // SkToPk
     pair::g2mul(&g, &sc).tobytes(w,true);  // true for public key compression

--- a/rust/bls192.rs
+++ b/rust/bls192.rs
@@ -115,7 +115,7 @@ pub fn key_pair_generate(ikm: &[u8], s: &mut [u8], w: &mut [u8]) -> isize {
     hmac::hkdf_expand(hmac::MC_SHA2,hlen,&mut okm,el,&prk[0 .. hlen],&len);
 
     let mut dx = DBIG::frombytes(&okm[0 .. el]);
-    let mut sc = dx.dmod(&r);
+    let sc = dx.dmod(&r);
     sc.tobytes(s);
 // SkToPk
     pair4::g2mul(&g, &sc).tobytes(w,true);  // true for public key compression

--- a/rust/bls256.rs
+++ b/rust/bls256.rs
@@ -114,7 +114,7 @@ pub fn key_pair_generate(ikm: &[u8], s: &mut [u8], w: &mut [u8]) -> isize {
     hmac::hkdf_expand(hmac::MC_SHA2,hlen,&mut okm,el,&prk[0 .. hlen],&len);
 
     let mut dx = DBIG::frombytes(&okm[0 .. el]);
-    let mut sc = dx.dmod(&r);
+    let sc = dx.dmod(&r);
     sc.tobytes(s);
 // SkToPk
     pair8::g2mul(&g, &sc).tobytes(w,true);  // true for public key compression

--- a/rust/mpin.rs
+++ b/rust/mpin.rs
@@ -78,7 +78,7 @@ pub fn encode_to_curve(dst: &[u8],id: &[u8],hcid: &mut [u8]) {
 /* create random secret S */
 pub fn random_generate(mut rng: &mut RAND, s: &mut [u8]) -> isize {
     let r = BIG::new_ints(&rom::CURVE_ORDER);
-    let mut sc = BIG::randtrunc(&r, 16 * ecp::AESKEY, &mut rng);
+    let sc = BIG::randtrunc(&r, 16 * ecp::AESKEY, &mut rng);
     sc.tobytes(s);
     return 0;
 }
@@ -145,7 +145,7 @@ pub fn client_1(
     xid: &mut [u8]
 ) -> isize {
     let r = BIG::new_ints(&rom::CURVE_ORDER);
-    let mut sx: BIG;
+    let sx: BIG;
 
     if let Some(rd) = rng {
         sx = BIG::randtrunc(&r, 16 * ecp::AESKEY, rd);

--- a/rust/mpin192.rs
+++ b/rust/mpin192.rs
@@ -78,7 +78,7 @@ pub fn encode_to_curve(dst: &[u8],id: &[u8],hcid: &mut [u8]) {
 /* create random secret S */
 pub fn random_generate(mut rng: &mut RAND, s: &mut [u8]) -> isize {
     let r = BIG::new_ints(&rom::CURVE_ORDER);
-    let mut sc = BIG::randtrunc(&r, 16 * ecp::AESKEY, &mut rng);
+    let sc = BIG::randtrunc(&r, 16 * ecp::AESKEY, &mut rng);
     sc.tobytes(s);
     return 0;
 }
@@ -145,7 +145,7 @@ pub fn client_1(
     xid: &mut [u8]
 ) -> isize {
     let r = BIG::new_ints(&rom::CURVE_ORDER);
-    let mut sx: BIG;
+    let sx: BIG;
 
     if let Some(rd) = rng {
         sx = BIG::randtrunc(&r, 16 * ecp::AESKEY, rd);

--- a/rust/mpin256.rs
+++ b/rust/mpin256.rs
@@ -78,7 +78,7 @@ pub fn encode_to_curve(dst: &[u8],id: &[u8],hcid: &mut [u8]) {
 /* create random secret S */
 pub fn random_generate(mut rng: &mut RAND, s: &mut [u8]) -> isize {
     let r = BIG::new_ints(&rom::CURVE_ORDER);
-    let mut sc = BIG::randtrunc(&r, 16 * ecp::AESKEY, &mut rng);
+    let sc = BIG::randtrunc(&r, 16 * ecp::AESKEY, &mut rng);
     sc.tobytes(s);
     return 0;
 }
@@ -145,7 +145,7 @@ pub fn client_1(
     xid: &mut [u8]
 ) -> isize {
     let r = BIG::new_ints(&rom::CURVE_ORDER);
-    let mut sx: BIG;
+    let sx: BIG;
 
     if let Some(rd) = rng {
         sx = BIG::randtrunc(&r, 16 * ecp::AESKEY, rd);


### PR DESCRIPTION
BIG::tobytearray copies before normalization, that is, it leaves the input
unchanged, so there's no need for mutability.