### PR TITLE
Implemment Debug, Display

### DIFF
--- a/rust/big.rs
+++ b/rust/big.rs
@@ -47,6 +47,17 @@ impl Clone for BIG {
     }
 }
 
+impl std::fmt::Debug for BIG {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "{}", self.tostring())
+    }
+}    
+impl std::fmt::Display for BIG {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "{}", self.tostring())
+    }
+}
+
 impl BIG {
     pub const fn new() -> BIG {
         BIG { w: [0; NLEN] }

--- a/rust/dbig.rs
+++ b/rust/dbig.rs
@@ -26,6 +26,17 @@ pub struct DBIG {
     pub w: [Chunk; big::DNLEN],
 }
 
+impl std::fmt::Debug for DBIG {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "{}", self.tostring())
+    }
+}    
+impl std::fmt::Display for DBIG {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "{}", self.tostring())
+    }
+}
+
 impl DBIG {
     pub fn new() -> DBIG {
         DBIG {
@@ -251,7 +262,7 @@ impl DBIG {
     }
 
     /* return number of bits */
-    pub fn nbits(&mut self) -> usize {
+    pub fn nbits(&self) -> usize {
         let mut k = big::DNLEN - 1;
         let mut s = DBIG::new_copy(&self);
         s.norm();
@@ -271,7 +282,7 @@ impl DBIG {
     }
 
     /* Convert to Hex String */
-    pub fn tostring(&mut self) -> String {
+    pub fn tostring(&self) -> String {
         let mut s = String::new();
         let mut len = self.nbits();
 

--- a/rust/ecp.rs
+++ b/rust/ecp.rs
@@ -31,6 +31,17 @@ pub struct ECP {
     z: FP,
 }
 
+impl std::fmt::Debug for ECP {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "{}", self.tostring())
+    }
+}    
+impl std::fmt::Display for ECP {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "{}", self.tostring())
+    }
+}
+
 pub const WEIERSTRASS: usize = 0;
 pub const EDWARDS: usize = 1;
 pub const MONTGOMERY: usize = 2;

--- a/rust/ecp2.rs
+++ b/rust/ecp2.rs
@@ -33,6 +33,17 @@ pub struct ECP2 {
     z: FP2,
 }
 
+impl std::fmt::Debug for ECP2 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "{}", self.tostring())
+    }
+}    
+impl std::fmt::Display for ECP2 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "{}", self.tostring())
+    }
+}
+
 #[allow(non_snake_case)]
 impl ECP2 {
     pub fn new() -> ECP2 {

--- a/rust/ecp4.rs
+++ b/rust/ecp4.rs
@@ -33,6 +33,17 @@ pub struct ECP4 {
     z: FP4,
 }
 
+impl std::fmt::Debug for ECP4 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "{}", self.tostring())
+    }
+}    
+impl std::fmt::Display for ECP4 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "{}", self.tostring())
+    }
+}
+
 #[allow(non_snake_case)]
 impl ECP4 {
     pub fn new() -> ECP4 {

--- a/rust/ecp8.rs
+++ b/rust/ecp8.rs
@@ -34,6 +34,17 @@ pub struct ECP8 {
     z: FP8,
 }
 
+impl std::fmt::Debug for ECP8 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "{}", self.tostring())
+    }
+}    
+impl std::fmt::Display for ECP8 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "{}", self.tostring())
+    }
+}
+
 #[allow(non_snake_case)]
 impl ECP8 {
     pub fn new() -> ECP8 {

--- a/rust/ff.rs
+++ b/rust/ff.rs
@@ -43,6 +43,17 @@ pub struct FF {
     length: usize,
 }
 
+impl std::fmt::Debug for FF {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "{}", self.tostring())
+    }
+}    
+impl std::fmt::Display for FF {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "{}", self.tostring())
+    }
+}
+
 impl FF {
     pub fn excess(a: &BIG) -> Chunk {
         return ((a.w[big::NLEN - 1] & P_OMASK) >> (P_TBITS)) + 1;

--- a/rust/fp.rs
+++ b/rust/fp.rs
@@ -32,6 +32,17 @@ pub struct FP {
     pub xes: i32,
 }
 
+impl std::fmt::Debug for FP {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "{}", self.tostring())
+    }
+}    
+impl std::fmt::Display for FP {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "{}", self.tostring())
+    }
+}
+
 pub const NOT_SPECIAL: usize = 0;
 pub const PSEUDO_MERSENNE: usize = 1;
 pub const MONTGOMERY_FRIENDLY: usize = 2;

--- a/rust/fp12.rs
+++ b/rust/fp12.rs
@@ -40,6 +40,17 @@ pub struct FP12 {
     stype: usize,
 }
 
+impl std::fmt::Debug for FP12 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "{}", self.tostring())
+    }
+}    
+impl std::fmt::Display for FP12 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "{}", self.tostring())
+    }
+}
+
 impl FP12 {
     pub fn new() -> FP12 {
         FP12 {

--- a/rust/fp16.rs
+++ b/rust/fp16.rs
@@ -29,6 +29,17 @@ pub struct FP16 {
     b: FP8,
 }
 
+impl std::fmt::Debug for FP16 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "{}", self.tostring())
+    }
+}    
+impl std::fmt::Display for FP16 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "{}", self.tostring())
+    }
+}
+
 impl FP16 {
     pub const fn new() -> FP16 {
         FP16 {

--- a/rust/fp2.rs
+++ b/rust/fp2.rs
@@ -32,6 +32,17 @@ pub struct FP2 {
     b: FP,
 }
 
+impl std::fmt::Debug for FP2 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "{}", self.tostring())
+    }
+}    
+impl std::fmt::Display for FP2 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "{}", self.tostring())
+    }
+}
+
 impl FP2 {
     pub const fn new() -> FP2 {
         FP2 {

--- a/rust/fp24.rs
+++ b/rust/fp24.rs
@@ -40,6 +40,17 @@ pub struct FP24 {
     stype: usize,
 }
 
+impl std::fmt::Debug for FP24 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "{}", self.tostring())
+    }
+}    
+impl std::fmt::Display for FP24 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "{}", self.tostring())
+    }
+}
+
 impl FP24 {
     pub fn new() -> FP24 {
         FP24 {

--- a/rust/fp4.rs
+++ b/rust/fp4.rs
@@ -32,6 +32,17 @@ pub struct FP4 {
     b: FP2,
 }
 
+impl std::fmt::Debug for FP4 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "{}", self.tostring())
+    }
+}    
+impl std::fmt::Display for FP4 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "{}", self.tostring())
+    }
+}
+
 impl FP4 {
     pub const fn new() -> FP4 {
         FP4 {

--- a/rust/fp48.rs
+++ b/rust/fp48.rs
@@ -40,6 +40,17 @@ pub struct FP48 {
     stype: usize,
 }
 
+impl std::fmt::Debug for FP48 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "{}", self.tostring())
+    }
+}    
+impl std::fmt::Display for FP48 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "{}", self.tostring())
+    }
+}
+
 impl FP48 {
     pub fn new() -> FP48 {
         FP48 {

--- a/rust/fp8.rs
+++ b/rust/fp8.rs
@@ -34,6 +34,17 @@ pub struct FP8 {
     b: FP4,
 }
 
+impl std::fmt::Debug for FP8 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "{}", self.tostring())
+    }
+}    
+impl std::fmt::Display for FP8 {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "{}", self.tostring())
+    }
+}
+
 impl FP8 {
     pub const fn new() -> FP8 {
         FP8 {


### PR DESCRIPTION
# Motivation
Rust has standard methods for formatting structures.  The advantage of using the standard methods that I am most interested in is that composite structures containing Miracl structures don't need to implement custom formatting.  With this PR, this becomes possible:

```
#[derive(Display, Debug)]
struct MyComposite {
  big:  BIG,
  ecp: ECP,
  ecp2: ECP2,
}

#[test]
fn can_print() {
    let my_composite = MyComposite { big: BIG::new(), ecp: ECP::new(), ecp2: ECP2::new() };
    println!("Display output: {}", &my_composite);
    println!("Compact debug output: {:?}", &my_composite);
    println!("Pretty debug output: {:#?}", &my_composite);
}
```
