### PR TITLE
nomut

### DIFF
--- a/rust/ecp.rs
+++ b/rust/ecp.rs
@@ -1236,24 +1236,24 @@ impl ECP {
         S.dbl();
         C.copy(&W[1]);
         W[0].copy(&C);
-        W[0].sub(&mut S); // copy to C is stupid Rust thing..
+        W[0].sub(&S); // copy to C is stupid Rust thing..
         C.copy(&W[2]);
         W[3].copy(&C);
-        W[3].add(&mut S);
+        W[3].add(&S);
         T.copy(&self);
         T.dbl();
         C.copy(&W[1]);
         W[5].copy(&C);
-        W[5].add(&mut T);
+        W[5].add(&T);
         C.copy(&W[2]);
         W[6].copy(&C);
-        W[6].add(&mut T);
+        W[6].add(&T);
         C.copy(&W[5]);
         W[4].copy(&C);
-        W[4].sub(&mut S);
+        W[4].sub(&S);
         C.copy(&W[6]);
         W[7].copy(&C);
-        W[7].add(&mut S);
+        W[7].add(&S);
 
         // if multiplier is odd, add 2, else add 1 to multiplier, and add 2P or P to correction
 
@@ -1277,7 +1277,7 @@ impl ECP {
         mt.norm();
         tf.cmove(&mt, s);
         S.cmove(&Q, ns);
-        C.add(&mut S);
+        C.add(&S);
 
         mt.copy(&te);
         mt.add(&tf);
@@ -1303,9 +1303,9 @@ impl ECP {
             T.selector(&W, w[i] as i32);
             S.dbl();
             S.dbl();
-            S.add(&mut T);
+            S.add(&T);
         }
-        S.sub(&mut C); /* apply correction */
+        S.sub(&C); /* apply correction */
         return S;
     }
 
@@ -1786,8 +1786,8 @@ CAISZF */
     pub fn mapit(h: &[u8]) -> ECP {
         let q = BIG::new_ints(&rom::MODULUS);
         let mut dx = DBIG::frombytes(h);
-        let mut x=dx.dmod(&q);
-        let mut P=ECP::hap2point(&mut x);
+        let x=dx.dmod(&q);
+        let mut P=ECP::hap2point(&x);
         P.cfp();
         return P;
     }

--- a/rust/ecp2.rs
+++ b/rust/ecp2.rs
@@ -572,7 +572,7 @@ impl ECP2 {
         for i in 1..8 {
             C.copy(&W[i - 1]);
             W[i].copy(&C);
-            W[i].add(&mut Q);
+            W[i].add(&Q);
         }
 
         /* make exponent odd - add 2P if even, P if odd */
@@ -606,9 +606,9 @@ impl ECP2 {
             P.dbl();
             P.dbl();
             P.dbl();
-            P.add(&mut Q);
+            P.add(&Q);
         }
-        P.sub(&mut C);
+        P.sub(&C);
         return P;
     }
 
@@ -619,11 +619,11 @@ impl ECP2 {
             X.inverse(None);
             X.norm();
         }
-        let mut x = BIG::new_ints(&rom::CURVE_BNX);
+        let x = BIG::new_ints(&rom::CURVE_BNX);
     // Faster Hashing to G2 - Fuentes-Castaneda, Knapp and Rodriguez-Henriquez
     // Q -> xQ + F(3xQ) + F(F(xQ)) + F(F(F(Q))).
         if ecp::CURVE_PAIRING_TYPE == ecp::BN {
-            let mut T = self.mul(&mut x);
+            let mut T = self.mul(&x);
             if ecp::SIGN_OF_X == ecp::NEGATIVEX {
                 T.neg();
             }
@@ -645,8 +645,8 @@ impl ECP2 {
     // Efficient hash maps to G2 on BLS curves - Budroni, Pintore
     // Q -> x2Q -xQ -Q +F(xQ -Q) +F(F(2Q))
         if ecp::CURVE_PAIRING_TYPE > ecp::BN {
-            let mut xQ = self.mul(&mut x);
-            let mut x2Q = xQ.mul(&mut x);
+            let mut xQ = self.mul(&x);
+            let mut x2Q = xQ.mul(&x);
 
             if ecp::SIGN_OF_X == ecp::NEGATIVEX {
                 xQ.neg();
@@ -972,8 +972,8 @@ CAHCZF */
     pub fn mapit(h: &[u8]) -> ECP2 {
         let q = BIG::new_ints(&rom::MODULUS);
         let mut dx = DBIG::frombytes(h);
-        let mut x=dx.dmod(&q);
-        let mut P=ECP2::hap2point(&mut x);
+        let x=dx.dmod(&q);
+        let mut P=ECP2::hap2point(&x);
         P.cfp();
         return P;
     }

--- a/rust/fp.rs
+++ b/rust/fp.rs
@@ -475,9 +475,9 @@ impl FP {
     }
     /* return jacobi symbol (this/Modulus) */
     pub fn jacobi(&mut self) -> isize {
-        let mut p = BIG::new_ints(&rom::MODULUS);
+        let p = BIG::new_ints(&rom::MODULUS);
         let mut w = self.redc();
-        return w.jacobi(&mut p);
+        return w.jacobi(&p);
     }
     /* return TRUE if self==a */
     pub fn equals(&self, a: &FP) -> bool {

--- a/rust/fp12.rs
+++ b/rust/fp12.rs
@@ -321,7 +321,7 @@ impl FP12 {
     pub fn mul(&mut self, y: &FP12) {
         let mut z0 = FP4::new_copy(&self.a);
         let mut z1 = FP4::new();
-        let mut z2 = FP4::new_copy(&mut self.b);
+        let mut z2 = FP4::new_copy(&self.b);
         let mut z3 = FP4::new();
         let mut t0 = FP4::new_copy(&self.a);
         let mut t1 = FP4::new_copy(&y.a);
@@ -977,15 +977,15 @@ impl FP12 {
         m.rmod(&r);
 
         let mut a = BIG::new_copy(&e);
-        a.rmod(&mut m);
+        a.rmod(&m);
 
         let mut b = BIG::new_copy(&e);
-        b.div(&mut m);
+        b.div(&m);
 
         let mut c = g1.trace();
 
         if b.iszilch() {
-            c = c.xtr_pow(&mut a);
+            c = c.xtr_pow(&a);
             return c;
         }
 
@@ -997,7 +997,7 @@ impl FP12 {
         g2.mul(&g1);
         let cpm2 = g2.trace();
 
-        c = c.xtr_pow2(&cp, &cpm1, &cpm2, &mut a, &mut b);
+        c = c.xtr_pow2(&cp, &cpm1, &cpm2, &a, &b);
 
         return c;
     }

--- a/rust/fp4.rs
+++ b/rust/fp4.rs
@@ -678,7 +678,7 @@ impl FP4 {
         for _ in 0..f2 {
             r.xtr_d()
         }
-        r = r.xtr_pow(&mut d);
+        r = r.xtr_pow(&d);
         return r;
     }
 

--- a/rust/mpin.rs
+++ b/rust/mpin.rs
@@ -96,7 +96,7 @@ pub fn extract_pin(cid: &[u8], pin: i32, token: &mut [u8]) -> isize {
     }
 
     R = R.pinmul(pin%MAXPIN, PBLEN);
-    P.sub(&mut R);
+    P.sub(&R);
     P.tobytes(token, false);
     return 0;
 }
@@ -104,7 +104,7 @@ pub fn extract_pin(cid: &[u8], pin: i32, token: &mut [u8]) -> isize {
 /* Implement step 2 on client side of MPin protocol */
 #[allow(non_snake_case)]
 pub fn client_2(x: &[u8], y: &[u8], sec: &mut [u8]) -> isize {
-    let mut r = BIG::new_ints(&rom::CURVE_ORDER);
+    let r = BIG::new_ints(&rom::CURVE_ORDER);
     let mut P = ECP::frombytes(sec);
     if P.is_infinity() {
         return INVALID_POINT;
@@ -113,7 +113,7 @@ pub fn client_2(x: &[u8], y: &[u8], sec: &mut [u8]) -> isize {
     let mut px = BIG::frombytes(x);
     let py = BIG::frombytes(y);
     px.add(&py);
-    px.rmod(&mut r);
+    px.rmod(&r);
 
     P = pair::g1mul(&P, &px);
     P.neg();
@@ -163,8 +163,8 @@ pub fn client_1(
         return INVALID_POINT;
     }
 
-    let mut W = P.pinmul((pin as i32) % MAXPIN, PBLEN);
-    T.add(&mut W);
+    let W = P.pinmul((pin as i32) % MAXPIN, PBLEN);
+    T.add(&W);
 
     P = pair::g1mul(&P, &sx);
     P.tobytes(xid, false);
@@ -210,7 +210,7 @@ pub fn server(
     }
 
     P = pair::g1mul(&P, &sy);
-    P.add(&mut R);
+    P.add(&R);
     R = ECP::frombytes(&msec);
     if R.is_infinity() {
         return INVALID_POINT;

--- a/rust/pair.rs
+++ b/rust/pair.rs
@@ -840,9 +840,9 @@ PFBNF */
         u[3].copy(&w);
         if ecp::SIGN_OF_X == ecp::NEGATIVEX {
             let mut t = BIG::new();
-            t.copy(&BIG::modneg(&mut u[1], &q));
+            t.copy(&BIG::modneg(&u[1], &q));
             u[1].copy(&t);
-            t.copy(&BIG::modneg(&mut u[3], &q));
+            t.copy(&BIG::modneg(&u[3], &q));
             u[3].copy(&t);
         }
     }
@@ -864,7 +864,7 @@ pub fn g1mul(P: &ECP, e: &BIG) -> ECP {
         Q.mulx(&mut cru);
 
         let mut np = u[0].nbits();
-        let mut t: BIG = BIG::modneg(&mut u[0], &q);
+        let mut t: BIG = BIG::modneg(&u[0], &q);
         let mut nn = t.nbits();
         if nn < np {
             u[0].copy(&t);
@@ -872,7 +872,7 @@ pub fn g1mul(P: &ECP, e: &BIG) -> ECP {
         }
 
         np = u[1].nbits();
-        t = BIG::modneg(&mut u[1], &q);
+        t = BIG::modneg(&u[1], &q);
         nn = t.nbits();
         if nn < np {
             u[1].copy(&t);
@@ -880,7 +880,7 @@ pub fn g1mul(P: &ECP, e: &BIG) -> ECP {
         }
         u[0].norm();
         u[1].norm();
-        R = R.mul2(&u[0], &mut Q, &u[1]);
+        R = R.mul2(&u[0], &Q, &u[1]);
     } else {
         R = P.mul(e);
     }
@@ -912,7 +912,7 @@ pub fn g2mul(P: &ECP2, e: &BIG) -> ECP2 {
         }
         for i in 0..4 {
             let np = u[i].nbits();
-            t.copy(&BIG::modneg(&mut u[i], &q));
+            t.copy(&BIG::modneg(&u[i], &q));
             let nn = t.nbits();
             if nn < np {
                 u[i].copy(&t);
@@ -921,7 +921,7 @@ pub fn g2mul(P: &ECP2, e: &BIG) -> ECP2 {
             u[i].norm();
         }
 
-        R.copy(&ECP2::mul4(&mut Q, &u));
+        R.copy(&ECP2::mul4(&Q, &u));
     } else {
         R.copy(&P.mul(e));
     }
@@ -948,7 +948,7 @@ pub fn gtpow(d: &FP12, e: &BIG) -> FP12 {
         }
         for i in 0..4 {
             let np = u[i].nbits();
-            t.copy(&BIG::modneg(&mut u[i], &q));
+            t.copy(&BIG::modneg(&u[i], &q));
             let nn = t.nbits();
             if nn < np {
                 u[i].copy(&t);
@@ -956,7 +956,7 @@ pub fn gtpow(d: &FP12, e: &BIG) -> FP12 {
             }
             u[i].norm();
         }
-        r.copy(&FP12::pow4(&mut g, &u));
+        r.copy(&FP12::pow4(&g, &u));
     } else {
         r.copy(&d.pow(e));
     }


### PR DESCRIPTION
# Changes
This removes the `mut` keyword from variable definitions and where variables are provided as arguments by reference where the variable or argument is not in fact mutated.

No APIs are changed.

# Motivation
I find that it makes code easier to read when the mutability of identifiers is labelled accurately.

I did not read through all the code; after reading through some of it I used `cargo clippy` to identify unnecessary `mut`.  This is by no means a complete solution but it did identify many cases.

# Testing
* I have run `config64.py` selecting a single algorithm and verified that the result satisfies `cargo check`.
* I have repeated this with each of the 42 algorithms.
* I also ran `config64.py test` for one algorithm; it built and ran all the tests successfully, including `TestNHS` which is the last on the list.