### PR TITLE
Idioms

### DIFF
--- a/rust/TestHPKE.rs
+++ b/rust/TestHPKE.rs
@@ -34,7 +34,7 @@ fn decode_hex(s: &str) -> Vec<u8> {
         let n2=cv[j+1] as usize;
 	    x.push(((n1 % 32 + 9) % 25 * 16 + (n2 % 32 + 9) % 25) as u8); j+=2;
     }
-    return x;
+    x
 }
 
 fn printbinary(array: &[u8]) {

--- a/rust/TestHTP.rs
+++ b/rust/TestHTP.rs
@@ -24,7 +24,7 @@ extern crate core;
 use core::hmac;
 
 fn ceil(a: usize,b: usize) -> usize {
-    return (a-1)/b+1;
+    (a-1)/b+1
 }
 
 fn hash_to_field_ed25519(hash: usize,hlen: usize,dst: &[u8],msg: &[u8],ctr: usize) -> [core::ed25519::fp::FP;2] {
@@ -53,7 +53,7 @@ fn hash_to_field_ed25519(hash: usize,hlen: usize,dst: &[u8],msg: &[u8],ctr: usiz
 		u[i].copy(&w);
     }
 
-    return u;
+    u
 }
 
 fn htp_ed25519(mess: &str) {
@@ -110,7 +110,7 @@ fn hash_to_field_c25519(hash: usize,hlen: usize,dst: &[u8],msg: &[u8],ctr: usize
 		u[i].copy(&w);
     }
 
-    return u;
+    u
 }
 
 fn htp_c25519(mess: &str) {
@@ -155,7 +155,7 @@ fn hash_to_field_nist256(hash: usize,hlen: usize,dst: &[u8],msg: &[u8],ctr: usiz
 		u[i].copy(&w);
     }
 
-    return u;
+    u
 }
 
 fn htp_nist256(mess: &str) {
@@ -213,7 +213,7 @@ fn hash_to_field_goldilocks(hash: usize,hlen: usize,dst: &[u8],msg: &[u8],ctr: u
 		u[i].copy(&w);
     }
 
-    return u;
+    u
 }
 
 fn htp_goldilocks(mess: &str) {
@@ -271,7 +271,7 @@ fn hash_to_field_secp256k1(hash: usize,hlen: usize,dst: &[u8],msg: &[u8],ctr: us
 		u[i].copy(&w);
     }
 
-    return u;
+    u
 }
 
 fn htp_secp256k1(mess: &str) {
@@ -329,7 +329,7 @@ fn hash_to_field_bls12381(hash: usize,hlen: usize,dst: &[u8],msg: &[u8],ctr: usi
 		u[i].copy(&w);
     }
 
-    return u;
+    u
 }
 
 fn htp_bls12381(mess: &str) {
@@ -394,7 +394,7 @@ fn hash_to_field2_bls12381(hash: usize,hlen: usize,dst: &[u8],msg: &[u8],ctr: us
 		u[i].copy(&FP2::new_fps(&w1,&w2));
     }
 
-    return u;
+    u
 }
 
 fn htp2_bls12381(mess: &str) {

--- a/rust/aes.rs
+++ b/rust/aes.rs
@@ -197,10 +197,10 @@ fn rotl24(x: u32) -> u32 {
 
 fn pack(b: [u8; 4]) -> u32 {
     /* pack bytes into a 32-bit Word */
-    ((((b[3]) & 0xff) as u32) << 24)
-        | ((((b[2]) & 0xff) as u32) << 16)
-        | ((((b[1]) & 0xff) as u32) << 8)
-        | (((b[0]) & 0xff) as u32)
+    ((b[3] as u32) << 24)
+        | ((b[2] as u32) << 16)
+        | ((b[1] as u32) << 8)
+        | (b[0] as u32)
 }
 
 fn unpack(a: u32) -> [u8; 4] {
@@ -258,8 +258,7 @@ fn invmixcol(x: u32) -> u32 {
     b[1] = product(m, x);
     m = rotl24(m);
     b[0] = product(m, x);
-    let y = pack(b);
-    y
+    pack(b)
 }
 
 fn increment(f: &mut [u8; 16]) {
@@ -802,7 +801,7 @@ pub fn cbc_iv0_decrypt(k: &[u8], c: &[u8]) -> Option<Vec<u8>> {
     let mut ipt = 0;
     let mut i;
 
-    if c.len() == 0 {
+    if c.is_empty() {
         return None;
     }
     let mut ch = c[ipt];

--- a/rust/aes.rs
+++ b/rust/aes.rs
@@ -184,34 +184,33 @@ pub struct AES {
 
 
 fn rotl8(x: u32) -> u32 {
-    return ((x) << 8) | ((x) >> 24);
+    ((x) << 8) | ((x) >> 24)
 }
 
 fn rotl16(x: u32) -> u32 {
-    return ((x) << 16) | ((x) >> 16);
+    ((x) << 16) | ((x) >> 16)
 }
 
 fn rotl24(x: u32) -> u32 {
-    return ((x) << 24) | ((x) >> 8);
+    ((x) << 24) | ((x) >> 8)
 }
 
 fn pack(b: [u8; 4]) -> u32 {
     /* pack bytes into a 32-bit Word */
-    return ((((b[3]) & 0xff) as u32) << 24)
+    ((((b[3]) & 0xff) as u32) << 24)
         | ((((b[2]) & 0xff) as u32) << 16)
         | ((((b[1]) & 0xff) as u32) << 8)
-        | (((b[0]) & 0xff) as u32);
+        | (((b[0]) & 0xff) as u32)
 }
 
 fn unpack(a: u32) -> [u8; 4] {
     /* unpack bytes from a word */
-    let b: [u8; 4] = [
+    [
         (a & 0xff) as u8,
         ((a >> 8) & 0xff) as u8,
         ((a >> 16) & 0xff) as u8,
         ((a >> 24) & 0xff) as u8,
-    ];
-    return b;
+    ]
 }
 
 fn bmul(x: u8, y: u8) -> u8 {
@@ -222,9 +221,9 @@ fn bmul(x: u8, y: u8) -> u8 {
     let ly = (LTAB[iy] as usize) & 0xff;
 
     if x != 0 && y != 0 {
-        return PTAB[(lx + ly) % 255];
+        PTAB[(lx + ly) % 255]
     } else {
-        return 0;
+        0
     }
 }
 
@@ -234,7 +233,7 @@ fn subbyte(a: u32) -> u32 {
     b[1] = FBSUB[b[1] as usize];
     b[2] = FBSUB[b[2] as usize];
     b[3] = FBSUB[b[3] as usize];
-    return pack(b);
+    pack(b)
 }
 
 fn product(x: u32, y: u32) -> u8 {
@@ -242,10 +241,10 @@ fn product(x: u32, y: u32) -> u8 {
     let xb = unpack(x);
     let yb = unpack(y);
 
-    return bmul(xb[0], yb[0])
+    bmul(xb[0], yb[0])
         ^ bmul(xb[1], yb[1])
         ^ bmul(xb[2], yb[2])
-        ^ bmul(xb[3], yb[3]);
+        ^ bmul(xb[3], yb[3])
 }
 
 fn invmixcol(x: u32) -> u32 {
@@ -260,7 +259,7 @@ fn invmixcol(x: u32) -> u32 {
     m = rotl24(m);
     b[0] = product(m, x);
     let y = pack(b);
-    return y;
+    y
 }
 
 fn increment(f: &mut [u8; 16]) {
@@ -378,7 +377,7 @@ impl AES {
         for j in n - 4..n {
             self.rkey[j + 4 - n] = self.fkey[j]
         }
-        return true;
+        true
     }
 
     pub fn getreg(&mut self) -> [u8; 16] {
@@ -386,7 +385,7 @@ impl AES {
         for i in 0..16 {
             ir[i] = self.f[i]
         }
-        return ir;
+        ir
     }
 
     /* Encrypt a single block */
@@ -576,7 +575,7 @@ impl AES {
         match self.mode {
             ECB => {
                 self.ecb_encrypt(buff);
-                return 0;
+                0
             }
             CBC => {
                 for j in 0..16 {
@@ -586,7 +585,7 @@ impl AES {
                 for j in 0..16 {
                     self.f[j] = buff[j]
                 }
-                return 0;
+                0
             }
 
             CFB1 | CFB2 | CFB4 => {
@@ -605,7 +604,7 @@ impl AES {
                     buff[j] ^= st[j];
                     self.f[16 - bytes + j] = buff[j];
                 }
-                return fell_off;
+                fell_off
             }
 
             OFB1 | OFB2 | OFB4 | OFB8 | OFB16 => {
@@ -623,7 +622,7 @@ impl AES {
 
                 //self.ecb_encrypt(&mut (self.f));
                 //for j in 0..bytes {buff[j]^=self.f[j]}
-                return 0;
+                0
             }
 
             CTR1 | CTR2 | CTR4 | CTR8 | CTR16 => {
@@ -636,11 +635,11 @@ impl AES {
                     buff[j] ^= st[j]
                 }
                 increment(&mut (self.f));
-                return 0;
+                0
             }
 
             _ => {
-                return 0;
+                0
             }
         }
     }
@@ -656,7 +655,7 @@ impl AES {
         match self.mode {
             ECB => {
                 self.ecb_decrypt(buff);
-                return 0;
+                0
             }
             CBC => {
                 for j in 0..16 {
@@ -668,7 +667,7 @@ impl AES {
                     buff[j] ^= st[j];
                     st[j] = 0;
                 }
-                return 0;
+                0
             }
             CFB1 | CFB2 | CFB4 => {
                 let bytes = self.mode - CFB1 + 1;
@@ -686,7 +685,7 @@ impl AES {
                     self.f[16 - bytes + j] = buff[j];
                     buff[j] ^= st[j];
                 }
-                return fell_off;
+                fell_off
             }
             OFB1 | OFB2 | OFB4 | OFB8 | OFB16 => {
                 let bytes = self.mode - OFB1 + 1;
@@ -702,7 +701,7 @@ impl AES {
                 }
                 //  self.ecb_encrypt(A.f[:]);
                 //  for j in 0..bytes {buff[j]^=self.f[j]}
-                return 0;
+                0
             }
 
             CTR1 | CTR2 | CTR4 | CTR8 | CTR16 => {
@@ -715,11 +714,11 @@ impl AES {
                     buff[j] ^= st[j]
                 }
                 increment(&mut (self.f));
-                return 0;
+                0
             }
 
             _ => {
-                return 0;
+                0
             }
         }
     }
@@ -786,7 +785,7 @@ pub fn cbc_iv0_encrypt(k: &[u8], m: &[u8]) -> Vec<u8> {
         c.push(buff[j]);
     }
     a.end();
-    return c;
+    c
 }
 
 /* returns plaintext if all consistent, else returns null string */
@@ -852,9 +851,10 @@ pub fn cbc_iv0_decrypt(k: &[u8], c: &[u8]) -> Option<Vec<u8>> {
     }
 
     if bad {
-        return None;
+        None
+    } else {
+        Some(m)
     }
-    return Some(m);
 }
 
 /*

--- a/rust/big.rs
+++ b/rust/big.rs
@@ -66,7 +66,7 @@ impl BIG {
     pub fn new_int(x: isize) -> BIG {
         let mut s = BIG::new();
         s.w[0] = x as Chunk;
-        return s;
+        s
     }
 
     pub fn new_ints(a: &[Chunk]) -> BIG {
@@ -74,7 +74,7 @@ impl BIG {
         for i in 0..NLEN {
             s.w[i] = a[i]
         }
-        return s;
+        s
     }
 
     pub fn new_copy(y: &BIG) -> BIG {
@@ -82,7 +82,7 @@ impl BIG {
         for i in 0..NLEN {
             s.w[i] = y.w[i]
         }
-        return s;
+        s
     }
 
     pub fn new_big(y: &BIG) -> BIG {
@@ -90,7 +90,7 @@ impl BIG {
         for i in 0..NLEN {
             s.w[i] = y.w[i]
         }
-        return s;
+        s
     }
 
     pub fn new_dcopy(y: &DBIG) -> BIG {
@@ -98,11 +98,11 @@ impl BIG {
         for i in 0..NLEN {
             s.w[i] = y.w[i]
         }
-        return s;
+        s
     }
 
     pub fn get(&self, i: usize) -> Chunk {
-        return self.w[i];
+        self.w[i]
     }
 
     pub fn set(&mut self, i: usize, x: Chunk) {
@@ -123,7 +123,7 @@ impl BIG {
         for i in 0..NLEN {
             d |= self.w[i];
         }
-        return (1 & ((d-1)>>BASEBITS)) != 0;
+        (1 & ((d-1)>>BASEBITS)) != 0
     }
 
     /* set to zero */
@@ -139,7 +139,7 @@ impl BIG {
         for i in 1..NLEN {
             d |= self.w[i];
         }
-        return (1 & ((d-1)>>BASEBITS) & (((self.w[0]^1)-1)>>BASEBITS)) != 0;
+        (1 & ((d-1)>>BASEBITS) & (((self.w[0]^1)-1)>>BASEBITS)) != 0
     }
 
     /* set to one */
@@ -168,7 +168,7 @@ impl BIG {
         let prod: DChunk = (a as DChunk) * (b as DChunk) + (c as DChunk) + (r as DChunk);
         let bot = (prod & (BMASK as DChunk)) as Chunk;
         let top = (prod >> BASEBITS) as Chunk;
-        return (top, bot);
+        (top, bot)
     }
 
     /* normalise BIG - force all digits < 2^BASEBITS */
@@ -181,7 +181,7 @@ impl BIG {
             carry = d >> BASEBITS;
         }
         self.w[NLEN - 1] += carry;
-        return (self.w[NLEN - 1] >> ((8 * MODBYTES) % BASEBITS)) as Chunk;
+        (self.w[NLEN - 1] >> ((8 * MODBYTES) % BASEBITS)) as Chunk
     }
 
     /* Conditional swap of two bigs depending on d using XOR - no branches */
@@ -210,7 +210,7 @@ impl BIG {
             self.w[i] = (self.w[i] >> k) | ((self.w[i + 1] << (BASEBITS - n)) & BMASK);
         }
         self.w[NLEN - 1] = self.w[NLEN - 1] >> k;
-        return w as isize;
+        w as isize
     }
 
     /* general shift right */
@@ -234,7 +234,7 @@ impl BIG {
             self.w[i] = ((self.w[i] << k) & BMASK) | (self.w[i - 1] >> (BASEBITS - n));
         }
         self.w[0] = (self.w[0] << n) & BMASK;
-        return (self.w[NLEN - 1] >> ((8 * MODBYTES) % BASEBITS)) as isize; /* return excess - only used in ff.c */
+        (self.w[NLEN - 1] >> ((8 * MODBYTES) % BASEBITS)) as isize /* return excess - only used in ff.c */
     }
 
     /* general shift left */
@@ -272,7 +272,7 @@ impl BIG {
             c /= 2;
             bts += 1;
         }
-        return bts;
+        bts
     }
 
     /* Convert to Hex String */
@@ -296,7 +296,7 @@ impl BIG {
             b.shr(i * 4);
             s = s + &format!("{:X}", b.w[0] & 15);
         }
-        return s;
+        s
     }
 
     pub fn fromstring(val: String) -> BIG {
@@ -311,7 +311,7 @@ impl BIG {
             let n = u8::from_str_radix(op, 16).unwrap();
             res.w[0] += n as Chunk;
         }
-        return res;
+        res
     }
 
     pub fn add(&mut self, r: &BIG) {
@@ -338,7 +338,7 @@ impl BIG {
         for i in 0..NLEN {
             s.w[i] = self.w[i] + x.w[i];
         }
-        return s;
+        s
     }
 
     pub fn inc(&mut self, x: isize) {
@@ -352,7 +352,7 @@ impl BIG {
         for i in 0..NLEN {
             d.w[i] = self.w[i] - x.w[i];
         }
-        return d;
+        d
     }
 
     /* self-=x */
@@ -401,7 +401,7 @@ impl BIG {
             m.fshl(8);
             m.w[0] += (b[i + n] & 0xff) as Chunk;
         }
-        return m;
+        m
     }
 
     pub fn tobytes(&self, b: &mut [u8]) {
@@ -409,7 +409,7 @@ impl BIG {
     }
 
     pub fn frombytes(b: &[u8]) -> BIG {
-        return BIG::frombytearray(b, 0);
+       BIG::frombytearray(b, 0)
     }
 
     /* self*=x, where x is >NEXCESS */
@@ -421,7 +421,7 @@ impl BIG {
             carry = tuple.0;
             self.w[i] = tuple.1;
         }
-        return carry;
+        carry
     }
 
     /* self*=c and catch overflow in DBIG */
@@ -434,7 +434,7 @@ impl BIG {
             m.w[j] = tuple.1;
         }
         m.w[NLEN] = carry;
-        return m;
+        m
     }
 
     /* divide by 3 */
@@ -447,7 +447,7 @@ impl BIG {
             self.w[i] = ak / 3;
             carry = ak % 3;
         }
-        return carry;
+        carry
     }
 
     /* return a*b where result fits in a BIG */
@@ -463,7 +463,7 @@ impl BIG {
                 }
             }
         }
-        return c;
+        c
     }
 
     /* Compare a and b, return 0 if a==b, -1 if a<b, +1 if a>b. Inputs must be normalised */
@@ -474,7 +474,7 @@ impl BIG {
  		    gt |= ((b.w[i]-a.w[i]) >> BASEBITS) & eq;
 		    eq &= ((b.w[i]^a.w[i])-1) >> BASEBITS;
         }
-        return (gt+gt+eq-1) as isize;
+        (gt+gt+eq-1) as isize
     }
 
     /* set x = x mod 2^m */
@@ -524,20 +524,20 @@ impl BIG {
         t1 <<= 4;
         u += t1;
 
-        return u;
+        u
     }
 
     /* return parity */
     pub fn parity(&self) -> isize {
-        return (self.w[0] % 2) as isize;
+        (self.w[0] % 2) as isize
     }
 
     /* return n-th bit */
     pub fn bit(&self, n: usize) -> isize {
         if (self.w[n / (BASEBITS as usize)] & (1 << (n % BASEBITS))) > 0 {
-            return 1;
+            1
         } else {
-            return 0;
+            0
         }
     }
 
@@ -545,7 +545,7 @@ impl BIG {
     pub fn lastbits(&mut self, n: usize) -> isize {
         let msk = ((1 << n) - 1) as Chunk;
         self.norm();
-        return (self.w[0] & msk) as isize;
+        (self.w[0] & msk) as isize
     }
 
     /* a=1/a mod 2^256. This is very fast! */
@@ -672,7 +672,7 @@ impl BIG {
             j += 1;
             j &= 7;
         }
-        return m;
+        m
     }
 
     /* Create random BIG in portable way, one bit at a time */
@@ -695,7 +695,7 @@ impl BIG {
             j &= 7;
         }
         let m = d.dmod(q);
-        return m;
+        m
     }
 
 /* create randum BIG less than r and less than trunc bits */
@@ -704,7 +704,7 @@ impl BIG {
 	    if q.nbits() > trunc {
 	        m.mod2m(trunc);
 	    }
-	    return m;
+	    m
     }
 
     /* Jacobi Symbol (this/p). Returns 0, 1 or -1 */
@@ -745,9 +745,9 @@ impl BIG {
             m %= 2;
         }
         if m == 0 {
-            return 1;
+            1
         } else {
-            return -1;
+            -1
         }
     }
 
@@ -837,7 +837,7 @@ impl BIG {
             t >>= rb;
         }
         c.w[2 * NLEN - 1] = t as Chunk;
-        return c;
+        c
     }
 
     /* return a^2 as DBIG */
@@ -907,7 +907,7 @@ impl BIG {
         co = t >> rb;
         c.w[DNLEN - 1] = co as Chunk;
 
-        return c;
+        c
     }
 
     /* Montgomery reduction */
@@ -952,7 +952,7 @@ impl BIG {
             s -= dd[k + 1 - NLEN];
         }
         b.w[NLEN - 1] = (t & rm) as Chunk;
-        return b;
+        b
     }
 
     /* Fast combined shift, subtract and norm. Return sign of result */
@@ -970,7 +970,7 @@ impl BIG {
         }
         m.w[n] >>= 1;
         r.w[n] = a.w[n] - m.w[n] + carry;
-        return ((r.w[n] >> (arch::CHUNK - 1)) & 1) as isize;
+        ((r.w[n] >> (arch::CHUNK - 1)) & 1) as isize
     }
 
     /* return a*b mod m */
@@ -980,7 +980,7 @@ impl BIG {
         a.rmod(m);
         b.rmod(m);
         let mut d = BIG::mul(&a, &b);
-        return d.dmod(m);
+        d.dmod(m)
     }
 
     /* return a^2 mod m */
@@ -988,7 +988,7 @@ impl BIG {
         let mut a = BIG::new_copy(a1);
         a.rmod(m);
         let mut d = BIG::sqr(&a);
-        return d.dmod(m);
+        d.dmod(m)
     }
 
     /* return -a mod m */
@@ -997,7 +997,7 @@ impl BIG {
         a.rmod(m);
 	    a.rsub(m);
 	    a.rmod(m);
-        return a;
+        a
     }
 
     /* return a+b mod m */
@@ -1008,7 +1008,7 @@ impl BIG {
         b.rmod(m);
         a.add(&b); a.norm();
         a.rmod(m);
-        return a;
+        a
     }
 
     /* return this^e mod m */
@@ -1030,6 +1030,6 @@ impl BIG {
             }
             s = BIG::modsqr(&mut s, m);
         }
-        return a;
+        a
     }
 }

--- a/rust/big.rs
+++ b/rust/big.rs
@@ -209,7 +209,7 @@ impl BIG {
         for i in 0..NLEN - 1 {
             self.w[i] = (self.w[i] >> k) | ((self.w[i + 1] << (BASEBITS - n)) & BMASK);
         }
-        self.w[NLEN - 1] = self.w[NLEN - 1] >> k;
+        self.w[NLEN - 1] >>= k;
         w as isize
     }
 
@@ -399,7 +399,7 @@ impl BIG {
         let mut m = BIG::new();
         for i in 0..(MODBYTES as usize) {
             m.fshl(8);
-            m.w[0] += (b[i + n] & 0xff) as Chunk;
+            m.w[0] += b[i + n] as Chunk;
         }
         m
     }
@@ -694,8 +694,7 @@ impl BIG {
             j += 1;
             j &= 7;
         }
-        let m = d.dmod(q);
-        m
+        d.dmod(q)
     }
 
 /* create randum BIG less than r and less than trunc bits */
@@ -941,7 +940,7 @@ impl BIG {
         }
 
         for k in NLEN..2 * NLEN - 1 {
-            t = t + s;
+            t += s;
             let mut i = 1 + k / 2;
             while i < NLEN {
                 t += ((v[k - i] - v[i]) as DChunk) * ((md.w[i] - md.w[k - i]) as DChunk);
@@ -1028,7 +1027,7 @@ impl BIG {
             if z.iszilch() {
                 break;
             }
-            s = BIG::modsqr(&mut s, m);
+            s = BIG::modsqr(&s, m);
         }
         a
     }

--- a/rust/bls.rs
+++ b/rust/bls.rs
@@ -67,7 +67,7 @@ fn hash_to_field(hash: usize,hlen: usize ,u: &mut [FP], dst: &[u8],m: &[u8],ctr:
 /* hash a message to an ECP point, using SHA2, random oracle method */
 #[allow(non_snake_case)]
 pub fn bls_hash_to_point(m: &[u8]) -> ECP {
-    let dst= String::from("BLS_SIG_ZZZG1_XMD:SHA-256_SVDW_RO_NUL_".to_ascii_uppercase());
+    let dst= "BLS_SIG_ZZZG1_XMD:SHA-256_SVDW_RO_NUL_".to_ascii_uppercase();
 //    let dst= String::from("BLS_SIG_ZZZG1_XMD:SHA-256_SSWU_RO_NUL_".to_ascii_uppercase());
 
     let mut u: [FP; 2] = [

--- a/rust/bls.rs
+++ b/rust/bls.rs
@@ -44,7 +44,7 @@ pub const BLS_FAIL: isize = -1;
 static mut G2_TAB: [FP4; ecp::G2_TABLE] = [FP4::new(); ecp::G2_TABLE];
 
 fn ceil(a: usize,b: usize) -> usize {
-    return (a-1)/b+1;
+    (a-1)/b+1
 }
 
 /* output u \in F_p */
@@ -82,7 +82,7 @@ pub fn bls_hash_to_point(m: &[u8]) -> ECP {
     P.add(&P1);
     P.cfp();
     P.affine();
-    return P;
+    P
 }
 
 pub fn init() -> isize {
@@ -93,7 +93,7 @@ pub fn init() -> isize {
     unsafe {
         pair::precomp(&mut G2_TAB, &g);
     }
-    return BLS_OK;
+    BLS_OK
 }
 
 /* generate key pair, private key s, public key w */
@@ -125,7 +125,7 @@ pub fn key_pair_generate(ikm: &[u8], s: &mut [u8], w: &mut [u8]) -> isize {
     sc.tobytes(s);
 // SkToPk
     pair::g2mul(&g, &sc).tobytes(w,true);  // true for public key compression
-    return BLS_OK;
+    BLS_OK
 }
 
 /* Sign message m using private key s to produce signature sig */
@@ -134,7 +134,7 @@ pub fn core_sign(sig: &mut [u8], m: &[u8], s: &[u8]) -> isize {
     let d = bls_hash_to_point(m);
     let sc = BIG::frombytes(&s);
     pair::g1mul(&d, &sc).tobytes(sig, true);
-    return BLS_OK;
+    BLS_OK
 }
 
 /* Verify signature given message m, the signature sig, and the public key w */
@@ -170,5 +170,5 @@ pub fn core_verify(sig: &[u8], m: &[u8], w: &[u8]) -> isize {
     if v.isunity() {
         return BLS_OK;
     }
-    return BLS_FAIL;
+    BLS_FAIL
 }

--- a/rust/bls192.rs
+++ b/rust/bls192.rs
@@ -41,7 +41,7 @@ pub const BLS_FAIL: isize = -1;
 static mut G2_TAB: [FP8; ecp::G2_TABLE] = [FP8::new(); ecp::G2_TABLE];
 
 fn ceil(a: usize,b: usize) -> usize {
-    return (a-1)/b+1;
+    (a-1)/b+1
 }
 
 /* output u \in F_p */
@@ -76,7 +76,7 @@ pub fn bls_hash_to_point(m: &[u8]) -> ECP {
     P.add(&P1);
     P.cfp();
     P.affine();
-    return P;
+    P
 }
 
 pub fn init() -> isize {
@@ -87,7 +87,7 @@ pub fn init() -> isize {
     unsafe {
         pair4::precomp(&mut G2_TAB, &g);
     }
-    return BLS_OK;
+    BLS_OK
 }
 
 /* generate key pair, private key s, public key w */
@@ -119,7 +119,7 @@ pub fn key_pair_generate(ikm: &[u8], s: &mut [u8], w: &mut [u8]) -> isize {
     sc.tobytes(s);
 // SkToPk
     pair4::g2mul(&g, &sc).tobytes(w,true);  // true for public key compression
-    return BLS_OK;
+    BLS_OK
 }
 
 /* Sign message m using private key s to produce signature sig */
@@ -128,7 +128,7 @@ pub fn core_sign(sig: &mut [u8], m: &[u8], s: &[u8]) -> isize {
     let d = bls_hash_to_point(m);
     let sc = BIG::frombytes(&s);
     pair4::g1mul(&d, &sc).tobytes(sig, true);
-    return BLS_OK;
+    BLS_OK
 }
 
 /* Verify signature given message m, the signature sig, and the public key w */
@@ -163,5 +163,5 @@ pub fn core_verify(sig: &[u8], m: &[u8], w: &[u8]) -> isize {
     if v.isunity() {
         return BLS_OK;
     }
-    return BLS_FAIL;
+    BLS_FAIL
 }

--- a/rust/bls256.rs
+++ b/rust/bls256.rs
@@ -40,7 +40,7 @@ pub const BLS_FAIL: isize = -1;
 static mut G2_TAB: [FP16; ecp::G2_TABLE] = [FP16::new(); ecp::G2_TABLE];
 
 fn ceil(a: usize,b: usize) -> usize {
-    return (a-1)/b+1;
+    (a-1)/b+1
 }
 
 /* output u \in F_p */
@@ -75,7 +75,7 @@ pub fn bls_hash_to_point(m: &[u8]) -> ECP {
     P.add(&P1);
     P.cfp();
     P.affine();
-    return P;
+    P
 }
 
 pub fn init() -> isize {
@@ -86,7 +86,7 @@ pub fn init() -> isize {
     unsafe {
         pair8::precomp(&mut G2_TAB, &g);
     }
-    return BLS_OK;
+    BLS_OK
 }
 
 /* generate key pair, private key s, public key w */
@@ -118,7 +118,7 @@ pub fn key_pair_generate(ikm: &[u8], s: &mut [u8], w: &mut [u8]) -> isize {
     sc.tobytes(s);
 // SkToPk
     pair8::g2mul(&g, &sc).tobytes(w,true);  // true for public key compression
-    return BLS_OK;
+    BLS_OK
 }
 
 /* Sign message m using private key s to produce signature sig */
@@ -127,7 +127,7 @@ pub fn core_sign(sig: &mut [u8], m: &[u8], s: &[u8]) -> isize {
     let d = bls_hash_to_point(m);
     let sc = BIG::frombytes(&s);
     pair8::g1mul(&d, &sc).tobytes(sig, true);
-    return BLS_OK;
+    BLS_OK
 }
 
 /* Verify signature given message m, the signature sig, and the public key w */
@@ -162,5 +162,5 @@ pub fn core_verify(sig: &[u8], m: &[u8], w: &[u8]) -> isize {
     if v.isunity() {
         return BLS_OK;
     }
-    return BLS_FAIL;
+    BLS_FAIL
 }

--- a/rust/dbig.rs
+++ b/rust/dbig.rs
@@ -172,7 +172,7 @@ impl DBIG {
         let mut m = DBIG::new();
         for i in 0..(b.len()) {
             m.shl(8);
-            m.w[0] += (b[i] & 0xff) as Chunk;
+            m.w[0] += b[i] as Chunk;
         }
         m
     }

--- a/rust/dbig.rs
+++ b/rust/dbig.rs
@@ -49,7 +49,7 @@ impl DBIG {
         for i in 0..big::DNLEN {
             s.w[i] = y.w[i]
         }
-        return s;
+        s
     }
 
     pub fn new_scopy(x: &BIG) -> DBIG {
@@ -63,7 +63,7 @@ impl DBIG {
         for i in big::NLEN + 1..big::DNLEN {
             b.w[i] = 0
         }
-        return b;
+        b
     }
 
     /* split DBIG at position n, return higher half, keep lower half */
@@ -78,7 +78,7 @@ impl DBIG {
             t.set(i + 1 - big::NLEN, nw);
         }
         self.w[big::NLEN - 1] &= ((1 as Chunk) << m) - 1;
-        return t;
+        t
     }
 
     /* general shift left */
@@ -164,7 +164,7 @@ impl DBIG {
   		    gt |= ((b.w[i]-a.w[i]) >> big::BASEBITS) & eq;
 		    eq &= ((b.w[i]^a.w[i])-1) >> big::BASEBITS;
         }
-        return (gt+gt+eq-1) as isize;
+        (gt+gt+eq-1) as isize
     }
 
     /* convert from byte array to BIG */
@@ -174,7 +174,7 @@ impl DBIG {
             m.shl(8);
             m.w[0] += (b[i] & 0xff) as Chunk;
         }
-        return m;
+        m
     }
 
     /* normalise BIG - force all digits < 2^big::BASEBITS */
@@ -222,8 +222,7 @@ impl DBIG {
 
             k -= 1;
         }
-        let r = BIG::new_dcopy(self);
-        return r;
+        BIG::new_dcopy(self)
     }
 
     /* return this/c */
@@ -258,7 +257,7 @@ impl DBIG {
 
             k -= 1;
         }
-        return a;
+        a
     }
 
     /* return number of bits */
@@ -278,7 +277,7 @@ impl DBIG {
             c /= 2;
             bts += 1;
         }
-        return bts;
+       bts
     }
 
     /* Convert to Hex String */
@@ -298,6 +297,6 @@ impl DBIG {
             b.shr(i * 4);
             s = s + &format!("{:X}", b.w[0] & 15);
         }
-        return s;
+        s
     }
 }

--- a/rust/ecdh.rs
+++ b/rust/ecdh.rs
@@ -45,7 +45,7 @@ pub fn in_range(s: &[u8]) -> bool {
     if BIG::comp(&sc, &r) >= 0 {
         return false;
     }
-    return true;
+    true
 }
 
 /* Calculate a public/private EC GF(p) key pair w,s where W=s.G mod EC(p),
@@ -74,7 +74,7 @@ pub fn key_pair_generate(rng: Option<&mut RAND>, s: &mut [u8], w: &mut [u8]) -> 
 
     WP.tobytes(w, false); // To use point compression on public keys, change to true
 
-    return res;
+    res
 }
 
 /* validate public key */
@@ -109,7 +109,7 @@ pub fn public_key_validate(w: &[u8]) -> isize {
             res = INVALID_PUBLIC_KEY
         }
     }
-    return res;
+    res
 }
 
 /* IEEE-1363 Diffie-Hellman online calculation Z=S.WD */
@@ -147,7 +147,7 @@ pub fn ecpsvdp_dh(s: &[u8], wd: &[u8], z: &mut [u8], typ: isize) -> isize {
             }
         }
     }
-    return res;
+    res
 }
 
 /* IEEE ECDSA Signature, C and D are signature on F using private key S */
@@ -212,7 +212,7 @@ pub fn ecpsp_dsa(
     for i in 0..EFS {
         d[i] = t[i]
     }
-    return 0;
+    0
 }
 
 /* IEEE1363 ECDSA Signature Verification. Signature C and D on F is verified using public key W */
@@ -265,7 +265,7 @@ pub fn ecpvp_dsa(sha: usize, w: &[u8], f: &[u8], c: &[u8], d: &[u8]) -> isize {
         }
     }
 
-    return res;
+    res
 }
 
 /* IEEE1363 ECIES encryption. Encryption of plaintext M uses public key W and produces ciphertext V,C,T */
@@ -328,7 +328,7 @@ pub fn ecies_encrypt(
         c.pop();
     }
 
-    return Some(c);
+    Some(c)
 }
 
 /* constant time n-byte compare */
@@ -340,7 +340,7 @@ fn ncomp(t1: &[u8], t2: &[u8], n: usize) -> bool {
     if res == 0 {
         return true;
     }
-    return false;
+    false
 }
 
 /* IEEE1363 ECIES decryption. Decryption of ciphertext V,C,T using private key U outputs plaintext M */
@@ -413,5 +413,5 @@ pub fn ecies_decrypt(
         return None;
     }
 
-    return m;
+    m
 }

--- a/rust/ecp.rs
+++ b/rust/ecp.rs
@@ -84,7 +84,7 @@ impl ECP {
         if CURVETYPE == EDWARDS {
             E.z.one();
         }
-        return E;
+        E
     }
 
     /* set (x,y) from two BIGs */
@@ -106,7 +106,7 @@ impl ECP {
                 E.inf();
             }
         }
-        return E;
+        E
     }
 
     /* set (x,y) from BIG and a bit */
@@ -128,7 +128,7 @@ impl ECP {
         } else {
             E.inf()
         }
-        return E;
+        E
     }
 
     #[allow(non_snake_case)]
@@ -147,7 +147,7 @@ impl ECP {
         } else {
             E.inf();
         }
-        return E;
+        E
     }
 
     /* set this=O */
@@ -206,7 +206,7 @@ impl ECP {
             r.add(&x);
         }
         r.reduce();
-        return r;
+        r
     }
 
     /* test for O point-at-infinity */
@@ -220,7 +220,7 @@ impl ECP {
         if CURVETYPE == MONTGOMERY {
             return self.z.iszilch();
         }
-        return true;
+        true
     }
 
     /* Conditional swap of P and Q dependant on d */
@@ -245,7 +245,7 @@ impl ECP {
     fn teq(b: i32, c: i32) -> isize {
         let mut x = b ^ c;
         x -= 1; // if x=0, x now -1
-        return ((x >> 31) & 1) as isize;
+        ((x >> 31) & 1) as isize
     }
 
     /* this=P */
@@ -317,7 +317,7 @@ impl ECP {
                 return false;
             }
         }
-        return true;
+        true
     }
 
     /* set to affine - from (x,y,z) to (x,y) */
@@ -345,7 +345,7 @@ impl ECP {
         let mut W = ECP::new();
         W.copy(self);
         W.affine();
-        return W.x.redc();
+        W.x.redc()
     }
 
     /* extract y as a BIG */
@@ -353,7 +353,7 @@ impl ECP {
         let mut W = ECP::new();
         W.copy(self);
         W.affine();
-        return W.y.redc();
+        W.y.redc()
     }
 
     /* get sign of Y */
@@ -361,24 +361,24 @@ impl ECP {
         let mut W = ECP::new();
         W.copy(self);
         W.affine();
-        return W.y.sign();
+        W.y.sign()
     }
 
     /* extract x as an FP */
     pub fn getpx(&self) -> FP {
         let w = FP::new_copy(&self.x);
-        return w;
+        w
     }
     /* extract y as an FP */
     pub fn getpy(&self) -> FP {
         let w = FP::new_copy(&self.y);
-        return w;
+        w
     }
 
     /* extract z as an FP */
     pub fn getpz(&self) -> FP {
         let w = FP::new_copy(&self.z);
-        return w;
+        w
     }
 
     /* convert to byte array */
@@ -502,7 +502,7 @@ impl ECP {
             }
         }
 
-        return ECP::new();
+        ECP::new()
     }
 
     /* convert to hex string */
@@ -1140,7 +1140,7 @@ impl ECP {
             }
             P.sub(&mut C); /* apply correction */
         }
-        return P;
+        P
     }
 
 // Generic multi-multiplication, fixed 4-bit window, P=Sigma e_i*X_i
@@ -1196,7 +1196,7 @@ impl ECP {
             }
             P.add(&S);
         }
-        return P;
+        P
     }
 
     /* Return e.this+f.Q */
@@ -1306,7 +1306,7 @@ impl ECP {
             S.add(&T);
         }
         S.sub(&C); /* apply correction */
-        return S;
+        S
     }
 
     pub fn cfp(&mut self) {
@@ -1347,7 +1347,7 @@ impl ECP {
                 break;
             }
         }
-        return P;
+        P
     }
 
 /* Constant time Map to Point */
@@ -1778,7 +1778,7 @@ CAHCZF */
 CAISZF */
             }
         }
-        return P;
+        P
     }
 
 /* Map byte string to curve point */
@@ -1789,7 +1789,7 @@ CAISZF */
         let x=dx.dmod(&q);
         let mut P=ECP::hap2point(&x);
         P.cfp();
-        return P;
+        P
     }
 
     pub fn generator() -> ECP {
@@ -1801,6 +1801,6 @@ CAISZF */
         } else {
             G = ECP::new_big(&gx);
         }
-        return G;
+        G
     }
 }

--- a/rust/ecp.rs
+++ b/rust/ecp.rs
@@ -267,7 +267,6 @@ impl ECP {
             self.x.neg();
             self.x.norm();
         }
-        return;
     }
     /* multiply x coordinate */
     pub fn mulx(&mut self, c: &mut FP) {
@@ -366,19 +365,16 @@ impl ECP {
 
     /* extract x as an FP */
     pub fn getpx(&self) -> FP {
-        let w = FP::new_copy(&self.x);
-        w
+        FP::new_copy(&self.x)
     }
     /* extract y as an FP */
     pub fn getpy(&self) -> FP {
-        let w = FP::new_copy(&self.y);
-        w
+        FP::new_copy(&self.y)
     }
 
     /* extract z as an FP */
     pub fn getpz(&self) -> FP {
-        let w = FP::new_copy(&self.z);
-        w
+        FP::new_copy(&self.z)
     }
 
     /* convert to byte array */
@@ -713,7 +709,6 @@ impl ECP {
             self.z.copy(&bb);
             self.z.mul(&c);
         }
-        return;
     }
 
     /* self+=Q */
@@ -969,7 +964,6 @@ impl ECP {
             self.z.copy(&f);
             self.z.mul(&g);
         }
-        return;
     }
 
     /* Differential Add for Montgomery curves. this+=Q where W is this-Q and is affine. */
@@ -1024,7 +1018,7 @@ impl ECP {
     /* constant time multiply by small integer of length bts - use ladder */
     pub fn pinmul(&self, e: i32, bts: i32) -> ECP {
         if CURVETYPE == MONTGOMERY {
-            return self.mul(&mut BIG::new_int(e as isize));
+            self.mul(&BIG::new_int(e as isize))
         } else {
             let mut P = ECP::new();
             let mut R0 = ECP::new();
@@ -1034,14 +1028,14 @@ impl ECP {
             for i in (0..bts).rev() {
                 let b = ((e >> i) & 1) as isize;
                 P.copy(&R1);
-                P.add(&mut R0);
+                P.add(&R0);
                 R0.cswap(&mut R1, b);
                 R1.copy(&P);
                 R0.dbl();
                 R0.cswap(&mut R1, b);
             }
             P.copy(&R0);
-            return P;
+            P
         }
     }
 
@@ -1066,7 +1060,7 @@ impl ECP {
             for i in (0..nb - 1).rev() {
                 let b = e.bit(i);
                 P.copy(&R1);
-                P.dadd(&mut R0, &D);
+                P.dadd(&R0, &D);
                 R0.cswap(&mut R1, b);
                 R1.copy(&P);
                 R0.dbl();
@@ -1102,7 +1096,7 @@ impl ECP {
             for i in 1..8 {
                 C.copy(&W[i - 1]);
                 W[i].copy(&C);
-                W[i].add(&mut Q);
+                W[i].add(&Q);
             }
 
             // make exponent odd - add 2P if even, P if odd
@@ -1136,9 +1130,9 @@ impl ECP {
                 P.dbl();
                 P.dbl();
                 P.dbl();
-                P.add(&mut Q);
+                P.add(&Q);
             }
-            P.sub(&mut C); /* apply correction */
+            P.sub(&C); /* apply correction */
         }
         P
     }

--- a/rust/ecp2.rs
+++ b/rust/ecp2.rs
@@ -68,7 +68,7 @@ impl ECP2 {
         if !y2.equals(&rhs) {
             E.inf();
         }
-        return E;
+        E
     }
 
     /* construct this from x - but set to O if not on curve */
@@ -90,12 +90,12 @@ impl ECP2 {
         } else {
             E.inf();
         }
-        return E;
+        E
     }
 
     /* Test this=O? */
     pub fn is_infinity(&self) -> bool {
-        return self.x.iszilch() && self.z.iszilch();
+        self.x.iszilch() && self.z.iszilch()
     }
 
     /* copy self=P */
@@ -130,7 +130,7 @@ impl ECP2 {
     fn teq(b: i32, c: i32) -> isize {
         let mut x = b ^ c;
         x -= 1; // if x=0, x now -1
-        return ((x >> 31) & 1) as isize;
+        ((x >> 31) & 1) as isize
     }
 
     /* Constant time select from pre-computed table */
@@ -173,7 +173,7 @@ impl ECP2 {
             return false;
         }
 
-        return true;
+        true
     }
 
     /* set to Affine - (x,y,z) to (x,y) */
@@ -199,7 +199,7 @@ impl ECP2 {
         let mut W = ECP2::new();
         W.copy(self);
         W.affine();
-        return FP2::new_copy(&W.x);
+        FP2::new_copy(&W.x)
     }
 
     /* extract affine y as FP2 */
@@ -207,20 +207,20 @@ impl ECP2 {
         let mut W = ECP2::new();
         W.copy(self);
         W.affine();
-        return FP2::new_copy(&W.y);
+        FP2::new_copy(&W.y)
     }
 
     /* extract projective x */
     pub fn getpx(&self) -> FP2 {
-        return FP2::new_copy(&self.x);
+        FP2::new_copy(&self.x)
     }
     /* extract projective y */
     pub fn getpy(&self) -> FP2 {
-        return FP2::new_copy(&self.y);
+        FP2::new_copy(&self.y)
     }
     /* extract projective z */
     pub fn getpz(&self) -> FP2 {
-        return FP2::new_copy(&self.z);
+        FP2::new_copy(&self.z)
     }
 
     /* convert to byte array */
@@ -282,7 +282,7 @@ impl ECP2 {
             alt=true;
         }
 
-	    if alt {
+	if alt {
             for i in 0..MB  {
 			    t[i]=b[i];
 		    }
@@ -293,7 +293,7 @@ impl ECP2 {
 				    t[i]=b[i+MB];
 			    }
                 let ry=FP2::frombytes(&t);
-                return ECP2::new_fp2s(&rx,&ry);
+                ECP2::new_fp2s(&rx,&ry)
             } else {
                 let sgn=(b[0]&0x20)>>5;
                 let mut P=ECP2::new_fp2(&rx,0);
@@ -301,21 +301,21 @@ impl ECP2 {
                 if (sgn == 1 && cmp != 1) || (sgn == 0 && cmp == 1) {
 				    P.neg();
 			    }
-                return P;
+                P
             }
         } else {
-		    for i in 0..MB {
-			    t[i]=b[i+1];
-		    }
+            for i in 0..MB {
+                 t[i]=b[i+1];
+            }
             let rx=FP2::frombytes(&t);
             if typ == 0x04 {
 		        for i in 0..MB {
 				    t[i]=b[i+MB+1];
 			    }
 		        let ry=FP2::frombytes(&t);
-		        return ECP2::new_fp2s(&rx,&ry)
+		        ECP2::new_fp2s(&rx,&ry)
             } else {
-                return ECP2::new_fp2(&rx,typ&1)
+                ECP2::new_fp2(&rx,typ&1)
             }
         }
     }
@@ -326,9 +326,10 @@ impl ECP2 {
         W.copy(self);
         W.affine();
         if W.is_infinity() {
-            return String::from("infinity");
+            String::from("infinity")
+        } else {
+            format!("({},{})", W.x.tostring(), W.y.tostring())
         }
-        return format!("({},{})", W.x.tostring(), W.y.tostring());
     }
 
     /* Calculate RHS of twisted curve equation x^3+B/i */
@@ -349,7 +350,7 @@ impl ECP2 {
         r.add(&b);
 
         r.reduce();
-        return r;
+        r
     }
 
     /* self+=self */
@@ -409,7 +410,7 @@ impl ECP2 {
         self.y.copy(&y3);
         self.y.norm();
 
-        return 1;
+        1
     }
 
     /* self+=Q - return 0 for add, 1 for double, -1 for O */
@@ -511,7 +512,7 @@ impl ECP2 {
         self.z.copy(&z3);
         self.z.norm();
 
-        return 0;
+        0
     }
 
     /* set this-=Q */
@@ -519,8 +520,7 @@ impl ECP2 {
         let mut NQ = ECP2::new();
         NQ.copy(Q);
         NQ.neg();
-        let d = self.add(&NQ);
-        return d;
+        self.add(&NQ)
     }
 
     /* set this*=q, where q is Modulus, using Frobenius */
@@ -609,7 +609,7 @@ impl ECP2 {
             P.add(&Q);
         }
         P.sub(&C);
-        return P;
+        P
     }
 
     #[allow(non_snake_case)]
@@ -774,7 +774,7 @@ impl ECP2 {
         W.sub(&Q[0]);
         P.cmove(&W, pb);
 
-        return P;
+        P
     }
 
 /* Hunt and Peck a BIG to a curve point */
@@ -792,7 +792,7 @@ impl ECP2 {
             x.inc(1);
             x.norm();
         }
-        return Q;
+        Q
     }
 
 /* Constant time Map to Point */
@@ -964,7 +964,7 @@ CAHCNZF */
 CAHCZF */
 
         }
-        return ECP2::new();
+        ECP2::new()
     }
 
 /* Map byte string to curve point */
@@ -975,11 +975,11 @@ CAHCZF */
         let x=dx.dmod(&q);
         let mut P=ECP2::hap2point(&x);
         P.cfp();
-        return P;
+        P
     }
 
     pub fn generator() -> ECP2 {
-        return ECP2::new_fp2s(
+        ECP2::new_fp2s(
             &FP2::new_bigs(
                 &BIG::new_ints(&rom::CURVE_PXA),
                 &BIG::new_ints(&rom::CURVE_PXB),
@@ -988,6 +988,6 @@ CAHCZF */
                 &BIG::new_ints(&rom::CURVE_PYA),
                 &BIG::new_ints(&rom::CURVE_PYB),
             ),
-        );
+        )
     }
 }

--- a/rust/ecp2.rs
+++ b/rust/ecp2.rs
@@ -757,7 +757,7 @@ impl ECP2 {
                 t[j].dec((bt >> 1) as isize);
                 t[j].norm();
                 w[i] += bt * (k as i8);
-                k = 2 * k;
+                k *= 2;
             }
         }
 

--- a/rust/ecp4.rs
+++ b/rust/ecp4.rs
@@ -68,7 +68,7 @@ impl ECP4 {
         if !y2.equals(&rhs) {
             E.inf();
         }
-        return E;
+        E
     }
 
     /* construct this from x - but set to O if not on curve */
@@ -91,12 +91,12 @@ impl ECP4 {
         } else {
             E.inf();
         }
-        return E;
+        E
     }
 
     /* Test this=O? */
     pub fn is_infinity(&self) -> bool {
-        return self.x.iszilch() && self.z.iszilch();
+        self.x.iszilch() && self.z.iszilch()
     }
 
     /* copy self=P */
@@ -131,7 +131,7 @@ impl ECP4 {
     fn teq(b: i32, c: i32) -> isize {
         let mut x = b ^ c;
         x -= 1; // if x=0, x now -1
-        return ((x >> 31) & 1) as isize;
+        ((x >> 31) & 1) as isize
     }
 
     /* Constant time select from pre-computed table */
@@ -174,7 +174,7 @@ impl ECP4 {
             return false;
         }
 
-        return true;
+        true
     }
 
     /* set to Affine - (x,y,z) to (x,y) */
@@ -200,7 +200,7 @@ impl ECP4 {
         let mut W = ECP4::new();
         W.copy(self);
         W.affine();
-        return FP4::new_copy(&self.x);
+        FP4::new_copy(&self.x)
     }
 
     /* extract affine y as FP4 */
@@ -208,20 +208,20 @@ impl ECP4 {
         let mut W = ECP4::new();
         W.copy(self);
         W.affine();
-        return FP4::new_copy(&W.y);
+        FP4::new_copy(&W.y)
     }
 
     /* extract projective x */
     pub fn getpx(&self) -> FP4 {
-        return FP4::new_copy(&self.x);
+        FP4::new_copy(&self.x)
     }
     /* extract projective y */
     pub fn getpy(&self) -> FP4 {
-        return FP4::new_copy(&self.y);
+        FP4::new_copy(&self.y)
     }
     /* extract projective z */
     pub fn getpz(&self) -> FP4 {
-        return FP4::new_copy(&self.z);
+        FP4::new_copy(&self.z)
     }
 
     /* convert to byte array */
@@ -294,7 +294,7 @@ impl ECP4 {
 				    t[i]=b[i+MB];
 			    }
                 let ry=FP4::frombytes(&t);
-                return ECP4::new_fp4s(&rx,&ry);
+                ECP4::new_fp4s(&rx,&ry)
             } else {
                 let sgn=(b[0]&0x20)>>5;
                 let mut P=ECP4::new_fp4(&rx,0);
@@ -302,7 +302,7 @@ impl ECP4 {
                 if (sgn == 1 && cmp != 1) || (sgn == 0 && cmp == 1) {
 				    P.neg();
 			    }
-                return P;
+                P
             }
         } else {
 		    for i in 0..MB {
@@ -314,9 +314,9 @@ impl ECP4 {
 				    t[i]=b[i+MB+1];
 			    }
 		        let ry=FP4::frombytes(&t);
-		        return ECP4::new_fp4s(&rx,&ry)
+		        ECP4::new_fp4s(&rx,&ry)
             } else {
-                return ECP4::new_fp4(&rx,typ&1)
+                ECP4::new_fp4(&rx,typ&1)
             }
         }
     }
@@ -327,9 +327,10 @@ impl ECP4 {
         W.copy(self);
         W.affine();
         if W.is_infinity() {
-            return String::from("infinity");
+            String::from("infinity")
+        } else {
+            format!("({},{})", W.x.tostring(), W.y.tostring())
         }
-        return format!("({},{})", W.x.tostring(), W.y.tostring());
     }
 
     /* Calculate RHS of twisted curve equation x^3+B/i */
@@ -349,7 +350,7 @@ impl ECP4 {
         r.add(&b);
 
         r.reduce();
-        return r;
+        r
     }
 
     /* self+=self */
@@ -407,7 +408,7 @@ impl ECP4 {
         self.y.copy(&y3);
         self.y.norm();
 
-        return 1;
+        1
     }
 
     /* self+=Q - return 0 for add, 1 for double, -1 for O */
@@ -503,7 +504,7 @@ impl ECP4 {
         self.z.copy(&z3);
         self.z.norm();
 
-        return 0;
+        0
     }
 
     /* set this-=Q */
@@ -511,8 +512,7 @@ impl ECP4 {
         let mut NQ = ECP4::new();
         NQ.copy(Q);
         NQ.neg();
-        let d = self.add(&NQ);
-        return d;
+        self.add(&NQ)
     }
 
     pub fn frob_constants() -> [FP2; 3] {
@@ -537,8 +537,7 @@ impl ECP4 {
         f0.norm();
         f1.mul(&f0);
 
-        let F: [FP2; 3] = [f0, f1, f2];
-        return F;
+        [f0, f1, f2]
     }
 
     /* set this*=q, where q is Modulus, using Frobenius */
@@ -629,7 +628,7 @@ impl ECP4 {
         }
         P.sub(&mut C);
         P.affine();
-        return P;
+        P
     }
 
     // Efficient hash maps to G2 on BLS curves - Budroni, Pintore
@@ -830,11 +829,11 @@ impl ECP4 {
 
         P.affine();
 
-        return P;
+        P
     }
 
     pub fn generator() -> ECP4 {
-        return ECP4::new_fp4s(
+        ECP4::new_fp4s(
             &FP4::new_fp2s(
                 &FP2::new_bigs(
                     &BIG::new_ints(&rom::CURVE_PXAA),
@@ -855,7 +854,7 @@ impl ECP4 {
                     &BIG::new_ints(&rom::CURVE_PYBB),
                 ),
             ),
-        );
+        )
     }
 
 /* Hunt and Peck a BIG to a curve point */
@@ -868,12 +867,11 @@ impl ECP4 {
             let X = FP4::new_fp2(&FP2::new_bigs(&one, &x));
             Q = ECP4::new_fp4(&X,0);
             if !Q.is_infinity() {
-                break;
+                break Q;
             }
             x.inc(1);
             x.norm();
         }
-        return Q;
     }
 
 /* Constant time Map to Point */
@@ -932,7 +930,7 @@ impl ECP4 {
         W.copy(&Y); W.neg(); W.norm();
         Y.cmove(&W,ne);
 
-        return ECP4::new_fp4s(&X3,&Y);
+        ECP4::new_fp4s(&X3,&Y)
     }
 
 /* Map byte string to curve point */
@@ -943,7 +941,7 @@ impl ECP4 {
         let mut x=dx.dmod(&q);
         let mut P=ECP4::hap2point(&mut x);
         P.cfp();
-        return P;
+        P
     }
 
 

--- a/rust/ecp8.rs
+++ b/rust/ecp8.rs
@@ -69,7 +69,7 @@ impl ECP8 {
         if !y2.equals(&rhs) {
             E.inf();
         }
-        return E;
+        E
     }
 
     /* construct this from x - but set to O if not on curve */
@@ -92,12 +92,12 @@ impl ECP8 {
         } else {
             E.inf();
         }
-        return E;
+        E
     }
 
     /* Test this=O? */
     pub fn is_infinity(&self) -> bool {
-        return self.x.iszilch() && self.z.iszilch();
+        self.x.iszilch() && self.z.iszilch()
     }
 
     /* copy self=P */
@@ -132,7 +132,7 @@ impl ECP8 {
     fn teq(b: i32, c: i32) -> isize {
         let mut x = b ^ c;
         x -= 1; // if x=0, x now -1
-        return ((x >> 31) & 1) as isize;
+        ((x >> 31) & 1) as isize
     }
 
     /* Constant time select from pre-computed table */
@@ -175,7 +175,7 @@ impl ECP8 {
             return false;
         }
 
-        return true;
+        true
     }
 
     /* set to Affine - (x,y,z) to (x,y) */
@@ -201,7 +201,7 @@ impl ECP8 {
         let mut W = ECP8::new();
         W.copy(self);
         W.affine();
-        return FP8::new_copy(&W.x);
+        FP8::new_copy(&W.x)
     }
 
     /* extract affine y as FP8 */
@@ -209,20 +209,20 @@ impl ECP8 {
         let mut W = ECP8::new();
         W.copy(self);
         W.affine();
-        return FP8::new_copy(&W.y);
+        FP8::new_copy(&W.y)
     }
 
     /* extract projective x */
     pub fn getpx(&self) -> FP8 {
-        return FP8::new_copy(&self.x);
+        FP8::new_copy(&self.x)
     }
     /* extract projective y */
     pub fn getpy(&self) -> FP8 {
-        return FP8::new_copy(&self.y);
+        FP8::new_copy(&self.y)
     }
     /* extract projective z */
     pub fn getpz(&self) -> FP8 {
-        return FP8::new_copy(&self.z);
+        FP8::new_copy(&self.z)
     }
 
     /* convert to byte array */
@@ -295,7 +295,7 @@ impl ECP8 {
 				    t[i]=b[i+MB];
 			    }
                 let ry=FP8::frombytes(&t);
-                return ECP8::new_fp8s(&rx,&ry);
+                ECP8::new_fp8s(&rx,&ry)
             } else {
                 let sgn=(b[0]&0x20)>>5;
                 let mut P=ECP8::new_fp8(&rx,0);
@@ -303,7 +303,7 @@ impl ECP8 {
                 if (sgn == 1 && cmp != 1) || (sgn == 0 && cmp == 1) {
 				    P.neg();
 			    }
-                return P;
+                P
             }
         } else {
 		    for i in 0..MB {
@@ -315,9 +315,9 @@ impl ECP8 {
 				    t[i]=b[i+MB+1];
 			    }
 		        let ry=FP8::frombytes(&t);
-		        return ECP8::new_fp8s(&rx,&ry)
+		        ECP8::new_fp8s(&rx,&ry)
             } else {
-                return ECP8::new_fp8(&rx,typ&1)
+                ECP8::new_fp8(&rx,typ&1)
             }
         }
     }
@@ -328,9 +328,10 @@ impl ECP8 {
         W.copy(self);
         W.affine();
         if W.is_infinity() {
-            return String::from("infinity");
+            String::from("infinity")
+        } else {
+            format!("({},{})", W.x.tostring(), W.y.tostring())
         }
-        return format!("({},{})", W.x.tostring(), W.y.tostring());
     }
 
     /* Calculate RHS of twisted curve equation x^3+B/i */
@@ -349,7 +350,7 @@ impl ECP8 {
         r.add(&b);
 
         r.reduce();
-        return r;
+        r
     }
 
     /* self+=self */
@@ -407,7 +408,7 @@ impl ECP8 {
         self.y.copy(&y3);
         self.y.norm();
 
-        return 1;
+        1
     }
 
     /* self+=Q - return 0 for add, 1 for double, -1 for O */
@@ -503,7 +504,7 @@ impl ECP8 {
         self.z.copy(&z3);
         self.z.norm();
 
-        return 0;
+        0
     }
 
     /* set this-=Q */
@@ -511,8 +512,7 @@ impl ECP8 {
         let mut NQ = ECP8::new();
         NQ.copy(Q);
         NQ.neg();
-        let d = self.add(&NQ);
-        return d;
+        self.add(&NQ)
     }
 
     pub fn frob_constants() -> [FP2; 3] {
@@ -552,7 +552,7 @@ impl ECP8 {
         }
 
         let F: [FP2; 3] = [f0, f1, f2];
-        return F;
+        F
     }
 
     /* set this*=q, where q is Modulus, using Frobenius */
@@ -656,7 +656,7 @@ impl ECP8 {
         }
         P.sub(&mut C);
         P.affine();
-        return P;
+        P
     }
 
     // Efficient hash maps to G2 on BLS curves - Budroni, Pintore
@@ -1020,11 +1020,11 @@ impl ECP8 {
 
         P.affine();
 
-        return P;
+        P
     }
 
     pub fn generator() -> ECP8 {
-        return ECP8::new_fp8s(
+        ECP8::new_fp8s(
             &FP8::new_fp4s(
                 &FP4::new_fp2s(
                     &FP2::new_bigs(
@@ -1069,7 +1069,7 @@ impl ECP8 {
                     ),
                 ),
             ),
-        );
+        )
     }
 
 /* Hunt and Peck a BIG to a curve point */
@@ -1082,12 +1082,11 @@ impl ECP8 {
             let X = FP8::new_fp4(&FP4::new_fp2(&FP2::new_bigs(&one, &x)));
             Q = ECP8::new_fp8(&X,0);
             if !Q.is_infinity() {
-                break;
+                break Q;
             }
             x.inc(1);
             x.norm();
         }
-        return Q;
     }
 
 /* Constant time Map to Point */
@@ -1146,7 +1145,7 @@ impl ECP8 {
         W.copy(&Y); W.neg(); W.norm();
         Y.cmove(&W,ne);
 
-        return ECP8::new_fp8s(&X3,&Y);
+        ECP8::new_fp8s(&X3,&Y)
     }
 
 /* Map byte string to curve point */
@@ -1157,7 +1156,7 @@ impl ECP8 {
         let mut x=dx.dmod(&q);
         let mut P=ECP8::hap2point(&mut x);
         P.cfp();
-        return P;
+        P
     }
 
 

--- a/rust/ff.rs
+++ b/rust/ff.rs
@@ -56,24 +56,18 @@ impl std::fmt::Display for FF {
 
 impl FF {
     pub fn excess(a: &BIG) -> Chunk {
-        return ((a.w[big::NLEN - 1] & P_OMASK) >> (P_TBITS)) + 1;
+        ((a.w[big::NLEN - 1] & P_OMASK) >> (P_TBITS)) + 1
     }
 
     pub fn pexceed(a: &BIG, b: &BIG) -> bool {
         let ea = FF::excess(a);
         let eb = FF::excess(b);
-        if ((ea + 1) as DChunk) * ((eb + 1) as DChunk) > P_FEXCESS as DChunk {
-            return true;
-        }
-        return false;
+        ((ea + 1) as DChunk) * ((eb + 1) as DChunk) > P_FEXCESS as DChunk
     }
 
     pub fn sexceed(a: &BIG) -> bool {
         let ea = FF::excess(a);
-        if ((ea + 1) as DChunk) * ((ea + 1) as DChunk) > P_FEXCESS as DChunk {
-            return true;
-        }
-        return false;
+        ((ea + 1) as DChunk) * ((ea + 1) as DChunk) > P_FEXCESS as DChunk
     }
 
     /* Constructors */
@@ -86,7 +80,7 @@ impl FF {
             f.v.push(BIG::new());
         }
         f.length = n;
-        return f;
+        f
     }
 
     pub fn zero(&mut self) {
@@ -96,7 +90,7 @@ impl FF {
     }
 
     pub fn getlen(&self) -> usize {
-        return self.length;
+        self.length
     }
 
     /* set to integer */
@@ -149,7 +143,7 @@ impl FF {
                 return false;
             }
         }
-        return true;
+        true
     }
 
     /* shift right by BIGBITS-bit words */
@@ -174,11 +168,11 @@ impl FF {
 
     /* extract last bit */
     pub fn parity(&self) -> isize {
-        return self.v[0].parity();
+        self.v[0].parity()
     }
 
     pub fn lastbits(&mut self, m: usize) -> isize {
-        return self.v[0].lastbits(m);
+        self.v[0].lastbits(m)
     }
 
     /* compare x and y - must be normalised, and of same length */
@@ -191,11 +185,10 @@ impl FF {
                 return j;
             }
             if i == 0 {
-                break;
+                return 0;
             }
             i -= 1;
         }
-        return 0;
     }
 
     /* recursive add */
@@ -334,7 +327,7 @@ impl FF {
             }
             i -= 1;
         }
-        return s;
+        s
     }
 
     /* Convert FFs to/from byte arrays */
@@ -480,7 +473,7 @@ impl FF {
         let mut z = FF::new_int(2 * n);
         let mut t = FF::new_int(2 * n);
         z.karmul(0, &x, 0, &y, 0, &mut t, 0, n);
-        return z;
+        z
     }
 
     /* return low part of product this*y */
@@ -526,7 +519,7 @@ impl FF {
         let mut z = FF::new_int(2 * n);
         let mut t = FF::new_int(2 * n);
         z.karsqr(0, &x, 0, &mut t, 0, n);
-        return z;
+        z
     }
 
     /* return This mod modulus, ms is modulus, md is Montgomery Constant */
@@ -546,7 +539,7 @@ impl FF {
         r.sub(&m);
         r.norm();
 
-        return r;
+        r
     }
 
     /* Set r=this mod b */
@@ -580,7 +573,7 @@ impl FF {
 
         r.copy(&x);
         r.rmod(b);
-        return r;
+        r
     }
 
     /* Set return=1/this mod p. Binary method - a<p on entry */
@@ -727,7 +720,7 @@ impl FF {
             i <<= 1;
         }
         u.norm();
-        return u;
+        u
     }
 
     pub fn random(&mut self, rng: &mut RAND) {
@@ -974,7 +967,7 @@ impl FF {
             xx = yy;
             yy = r;
         }
-        return yy;
+        yy
     }
 
     /* quick and dirty check for common factor with n */
@@ -1005,10 +998,7 @@ impl FF {
 
         let g = x.v[0].get(0) as isize;
         let r = FF::igcd(s, g);
-        if r > 1 {
-            return true;
-        }
-        return false;
+        r > 1
     }
 
     /* Miller-Rabin test for primality. Slow. */
@@ -1066,6 +1056,6 @@ impl FF {
             return false;
         }
 
-        return true;
+        true
     }
 }

--- a/rust/fp.rs
+++ b/rust/fp.rs
@@ -86,28 +86,28 @@ impl FP {
             f.x.inc(a);
         }
         f.nres();
-        return f;
+        f
     }
 
     pub fn new_copy(y: &FP) -> FP {
         let mut f = FP::new();
         f.x.copy(&(y.x));
         f.xes = y.xes;
-        return f;
+        f
     }
 
     pub fn new_big(y: &BIG) -> FP {
         let mut f = FP::new();
         f.x.copy(y);
         f.nres();
-        return f;
+        f
     }
 
     pub fn new_rand(rng: &mut RAND) -> FP {
         let m = BIG::new_ints(&rom::MODULUS);
         let w = BIG::randomnum(&m,rng);
         let f = FP::new_big(&w);
-        return f;
+        f
     }
 
     pub fn nres(&mut self) {
@@ -127,10 +127,9 @@ impl FP {
     pub fn redc(&self) -> BIG {
         if MODTYPE != PSEUDO_MERSENNE && MODTYPE != GENERALISED_MERSENNE {
             let mut d = DBIG::new_scopy(&(self.x));
-            return FP::modulo(&mut d);
+            FP::modulo(&mut d)
         } else {
-            let r = BIG::new_copy(&(self.x));
-            return r;
+            BIG::new_copy(&(self.x))
         }
     }
 
@@ -204,13 +203,12 @@ impl FP {
             let m = BIG::new_ints(&rom::MODULUS);
             return BIG::monty(&m, rom::MCONST, d);
         }
-        return BIG::new();
+        BIG::new()
     }
 
     /* convert to string */
     pub fn tostring(&self) -> String {
-        let s = self.redc().tostring();
-        return s;
+        self.redc().tostring()
     }
 
     /* reduce this mod Modulus */
@@ -244,7 +242,7 @@ impl FP {
     pub fn iszilch(&self) -> bool {
         let mut a = FP::new_copy(self);
         a.reduce();
-        return a.x.iszilch();
+        a.x.iszilch()
     }
 
     pub fn islarger(&self) -> isize {
@@ -254,7 +252,7 @@ impl FP {
         let mut sx = BIG::new_ints(&rom::MODULUS);
         let fx=self.redc();
         sx.sub(&fx); sx.norm();
-        return BIG::comp(&fx,&sx);
+        BIG::comp(&fx,&sx)
     }
 
     pub fn tobytes(&self,b: &mut [u8]) {
@@ -263,14 +261,14 @@ impl FP {
 
     pub fn frombytes(b: &[u8]) -> FP {
         let t=BIG::frombytes(b);
-        return FP::new_big(&t);
+        FP::new_big(&t)
     }
 
     /* test this=0? */
     pub fn isunity(&self) -> bool {
         let mut a = FP::new_copy(self);
         a.reduce();
-        return a.redc().isunity();
+        a.redc().isunity()
     }
 
     pub fn sign(&self) -> isize {
@@ -282,11 +280,11 @@ impl FP {
             n.reduce();
             let w=n.redc();
             let cp=BIG::comp(&w,&m);
-            return ((cp+1)&2)>>1;
+            ((cp+1)&2)>>1
         } else {
             let mut a = FP::new_copy(self);
             a.reduce();
-            return a.redc().parity();
+            a.redc().parity()
         }
     }
 
@@ -357,8 +355,7 @@ impl FP {
 
         v = v - ((v >> 1) & 0x55555555);
         v = (v & 0x33333333) + ((v >> 2) & 0x33333333);
-        let r = ((((v + (v >> 4)) & 0xF0F0F0F).wrapping_mul(0x1010101)) >> 24) as usize;
-        return r;
+        ((((v + (v >> 4)) & 0xF0F0F0F).wrapping_mul(0x1010101)) >> 24) as usize
     }
 
     // find appoximation to quotient of a/m
@@ -371,11 +368,11 @@ impl FP {
             let sh = hb - TBITS;
             let num = (n.w[big::NLEN - 1] << sh) | (n.w[big::NLEN - 2] >> (big::BASEBITS - sh));
             let den = (m.w[big::NLEN - 1] << sh) | (m.w[big::NLEN - 2] >> (big::BASEBITS - sh));
-            return (num / (den + 1)) as isize;
+            (num / (den + 1)) as isize
         } else {
             let num = n.w[big::NLEN - 1];
             let den = m.w[big::NLEN - 1];
-            return (num / (den + 1)) as isize;
+            (num / (den + 1)) as isize
         }
     }
 
@@ -477,7 +474,7 @@ impl FP {
     pub fn jacobi(&mut self) -> isize {
         let p = BIG::new_ints(&rom::MODULUS);
         let mut w = self.redc();
-        return w.jacobi(&p);
+        w.jacobi(&p)
     }
     /* return TRUE if self==a */
     pub fn equals(&self, a: &FP) -> bool {
@@ -485,10 +482,7 @@ impl FP {
         let mut s = FP::new_copy(a);
         f.reduce();
         s.reduce();
-        if BIG::comp(&(f.x), &(s.x)) == 0 {
-            return true;
-        }
-        return false;
+        BIG::comp(&(f.x), &(s.x)) == 0
     }
 
     /* return self^e mod Modulus */
@@ -545,7 +539,7 @@ impl FP {
             r.mul(&tb[w[i] as usize])
         }
         r.reduce();
-        return r;
+        r
     }
 
     // See eprint paper https://eprint.iacr.org/2018/1038
@@ -705,7 +699,7 @@ impl FP {
             r.sqr();
             nd-=1;
         }
-        return r;
+        r
     }
 
     /* Pseudo_inverse square root */
@@ -760,7 +754,7 @@ impl FP {
             r.sqr();
         }
 
-        return r.isunity() as isize;
+        r.isunity() as isize
     }
 
     pub fn invsqrt(&self,i: &mut FP,s: &mut FP) -> isize {
@@ -769,7 +763,7 @@ impl FP {
         s.copy(&self.sqrt(Some(&h)));
         i.copy(self);
         i.inverse(Some(&h));
-        return qr;
+        qr
     }
 
 // Two for the price of One  - See Hamburg https://eprint.iacr.org/2012/309.pdf
@@ -782,7 +776,7 @@ impl FP {
         let qr=t.invsqrt(&mut i,&mut s);
         i.mul(&w);
         s.mul(&i);
-        return qr;
+        qr
     }
 
     /* return sqrt(this) mod Modulus */
@@ -822,7 +816,7 @@ impl FP {
         let mut nr=FP::new_copy(&r);
         nr.neg(); nr.norm();
         r.cmove(&nr,sgn);
-        return r;
+        r
     }
 
 }

--- a/rust/fp.rs
+++ b/rust/fp.rs
@@ -106,8 +106,7 @@ impl FP {
     pub fn new_rand(rng: &mut RAND) -> FP {
         let m = BIG::new_ints(&rom::MODULUS);
         let w = BIG::randomnum(&m,rng);
-        let f = FP::new_big(&w);
-        f
+        FP::new_big(&w)
     }
 
     pub fn nres(&mut self) {
@@ -232,7 +231,7 @@ impl FP {
         while sb > 0 {
             let sr = BIG::ssn(&mut r, &self.x, &mut m);
             self.x.cmove(&r, 1 - sr);
-            sb = sb - 1;
+            sb -= 1;
         }
 
         self.xes = 1;
@@ -383,7 +382,7 @@ impl FP {
 
         p.fshl(sb);
         self.x.rsub(&p);
-        self.xes = 1 << (sb as i32) + 1;
+        self.xes = 1 << ((sb as i32) + 1);
         if self.xes > FEXCESS {
             self.reduce()
         }
@@ -402,14 +401,12 @@ impl FP {
             let mut d = self.x.pxmul(cc);
             self.x.copy(&FP::modulo(&mut d));
             self.xes = 2
+        } else if self.xes * (cc as i32) <= FEXCESS {
+            self.x.pmul(cc);
+            self.xes *= cc as i32;
         } else {
-            if self.xes * (cc as i32) <= FEXCESS {
-                self.x.pmul(cc);
-                self.xes *= cc as i32;
-            } else {
-                let n = FP::new_int(cc);
-                self.mul(&n);
-            }
+            let n = FP::new_int(cc);
+            self.mul(&n);
         }
 
         if s {

--- a/rust/fp12.rs
+++ b/rust/fp12.rs
@@ -650,14 +650,12 @@ impl FP12 {
                     let mut t = FP::new_copy(&self.b.geta().getA());
                     t.mul(&y.b.geta().getA());
                     w3 = FP2::new_fp(&t);
+                } else if y.stype != SPARSEST {
+                    w3 = FP2::new_copy(&y.b.geta());
+                    w3.pmul(&self.b.geta().getA());
                 } else {
-                    if y.stype != SPARSEST {
-                        w3 = FP2::new_copy(&y.b.geta());
-                        w3.pmul(&self.b.geta().getA());
-                    } else {
-                        w3 = FP2::new_copy(&self.b.geta());
-                        w3.pmul(&y.b.geta().getA());
-                    }
+                    w3 = FP2::new_copy(&self.b.geta());
+                    w3.pmul(&y.b.geta().getA());
                 }
             } else {
                 w3 = FP2::new_copy(&self.b.geta());
@@ -725,14 +723,12 @@ impl FP12 {
                     let mut t = FP::new_copy(&self.c.getb().getA());
                     t.mul(&y.c.getb().getA());
                     w3 = FP2::new_fp(&t);
+                } else if y.stype != SPARSEST {
+                    w3 = FP2::new_copy(&y.c.getb());
+                    w3.pmul(&self.c.getb().getA());
                 } else {
-                    if y.stype != SPARSEST {
-                        w3 = FP2::new_copy(&y.c.getb());
-                        w3.pmul(&self.c.getb().getA());
-                    } else {
-                        w3 = FP2::new_copy(&self.c.getb());
-                        w3.pmul(&y.c.getb().getA());
-                    }
+                    w3 = FP2::new_copy(&self.c.getb());
+                    w3.pmul(&y.c.getb().getA());
                 }
             } else {
                 w3 = FP2::new_copy(&self.c.getb());
@@ -1088,7 +1084,7 @@ impl FP12 {
                 t[j].dec((bt >> 1) as isize);
                 t[j].norm();
                 w[i] += bt * (k as i8);
-                k = 2 * k;
+                k *= 2;
             }
         }
 

--- a/rust/fp12.rs
+++ b/rust/fp12.rs
@@ -66,7 +66,7 @@ impl FP12 {
     }
 
     pub fn gettype(&self) -> usize {
-        return self.stype;
+        self.stype
     }
 
     pub fn new_int(a: isize) -> FP12 {
@@ -79,7 +79,7 @@ impl FP12 {
         } else {
             f.stype = SPARSEST;
         }
-        return f;
+        f
     }
 
     pub fn new_copy(x: &FP12) -> FP12 {
@@ -88,7 +88,7 @@ impl FP12 {
         f.b.copy(&x.b);
         f.c.copy(&x.c);
         f.stype = x.stype;
-        return f;
+        f
     }
 
     pub fn new_fp4s(d: &FP4, e: &FP4, f: &FP4) -> FP12 {
@@ -97,7 +97,7 @@ impl FP12 {
         g.b.copy(e);
         g.c.copy(f);
         g.stype = DENSE;
-        return g;
+        g
     }
 
     pub fn new_fp4(d: &FP4) -> FP12 {
@@ -106,7 +106,7 @@ impl FP12 {
         g.b.zero();
         g.c.zero();
         g.stype = SPARSEST;
-        return g;
+        g
     }
 
     /* reduce components mod Modulus */
@@ -126,7 +126,7 @@ impl FP12 {
     /* test self=0 ? */
     pub fn iszilch(&self) -> bool {
         //self.reduce();
-        return self.a.iszilch() && self.b.iszilch() && self.c.iszilch();
+        self.a.iszilch() && self.b.iszilch() && self.c.iszilch()
     }
 
     /* Conditional move of g to self dependant on d */
@@ -143,7 +143,7 @@ impl FP12 {
     fn teq(b: i32, c: i32) -> isize {
         let mut x = b ^ c;
         x -= 1; // if x=0, x now -1
-        return ((x >> 31) & 1) as isize;
+        ((x >> 31) & 1) as isize
     }
 
     /* Constant time select from pre-computed table */
@@ -170,28 +170,28 @@ impl FP12 {
     /* test self=1 ? */
     pub fn isunity(&self) -> bool {
         let one = FP4::new_int(1);
-        return self.a.equals(&one) && self.b.iszilch() && self.c.iszilch();
+        self.a.equals(&one) && self.b.iszilch() && self.c.iszilch()
     }
 
     /* test self=x */
     pub fn equals(&self, x: &FP12) -> bool {
-        return self.a.equals(&x.a) && self.b.equals(&x.b) && self.c.equals(&x.c);
+        self.a.equals(&x.a) && self.b.equals(&x.b) && self.c.equals(&x.c)
     }
 
     pub fn geta(&mut self) -> FP4 {
-        return self.a;
+        self.a
         //        let f = FP4::new_copy(&self.a);
         //        return f;
     }
 
     pub fn getb(&mut self) -> FP4 {
-        return self.b;
+        self.b
         //        let f = FP4::new_copy(&self.b);
         //        return f;
     }
 
     pub fn getc(&mut self) -> FP4 {
-        return self.c;
+        self.c
         //        let f = FP4::new_copy(&self.c);
         //        return f;
     }
@@ -866,7 +866,7 @@ impl FP12 {
         t.copy(&self.a);
         t.imul(3);
         t.reduce();
-        return t;
+        t
     }
 
     /* convert from byte array to FP12 */
@@ -885,7 +885,7 @@ impl FP12 {
 		    t[i]=w[i+2*MB];
 	    }
         let a=FP4::frombytes(&t);
-	    return FP12::new_fp4s(&a,&b,&c);
+	    FP12::new_fp4s(&a,&b,&c)
     }
 
     /* convert this to byte array */
@@ -909,12 +909,12 @@ impl FP12 {
 
     /* output to hex string */
     pub fn tostring(&self) -> String {
-        return format!(
+        format!(
             "[{},{},{}]",
             self.a.tostring(),
             self.b.tostring(),
             self.c.tostring()
-        );
+        )
     }
 
 /* Note this is simple square and multiply, so not side-channel safe */
@@ -949,7 +949,7 @@ impl FP12 {
         }
 
         w.reduce();
-        return w;
+        w
     }
 
     /* constant time powering by small integer of max length bts */
@@ -997,9 +997,7 @@ impl FP12 {
         g2.mul(&g1);
         let cpm2 = g2.trace();
 
-        c = c.xtr_pow2(&cp, &cpm1, &cpm2, &a, &b);
-
-        return c;
+        c.xtr_pow2(&cp, &cpm1, &cpm2, &a, &b)
     }
 
     /* p=q0^u0.q1^u1.q2^u2.q3^u3 */
@@ -1108,6 +1106,6 @@ impl FP12 {
         r.mul(&p);
         p.cmove(&r, pb);
         p.reduce();
-        return p;
+        p
     }
 }

--- a/rust/fp16.rs
+++ b/rust/fp16.rs
@@ -52,28 +52,28 @@ impl FP16 {
         let mut f = FP16::new();
         f.a.copy(&FP8::new_int(a));
         f.b.zero();
-        return f;
+        f
     }
 
     pub fn new_copy(x: &FP16) -> FP16 {
         let mut f = FP16::new();
         f.a.copy(&x.a);
         f.b.copy(&x.b);
-        return f;
+        f
     }
 
     pub fn new_fp8s(c: &FP8, d: &FP8) -> FP16 {
         let mut f = FP16::new();
         f.a.copy(c);
         f.b.copy(d);
-        return f;
+        f
     }
 
     pub fn new_fp8(c: &FP8) -> FP16 {
         let mut f = FP16::new();
         f.a.copy(c);
         f.b.zero();
-        return f;
+        f
     }
 
     pub fn set_fp8s(&mut self, c: &FP8, d: &FP8) {
@@ -110,7 +110,7 @@ impl FP16 {
 
     /* test self=0 ? */
     pub fn iszilch(&self) -> bool {
-        return self.a.iszilch() && self.b.iszilch();
+        self.a.iszilch() && self.b.iszilch()
     }
 
     pub fn tobytes(&self,bf: &mut [u8]) {
@@ -137,38 +137,35 @@ impl FP16 {
             t[i]=bf[i+MB];
         }
         let ta=FP8::frombytes(&t);
-        return FP16::new_fp8s(&ta,&tb);
+        FP16::new_fp8s(&ta,&tb)
     }
 
     /* test self=1 ? */
     pub fn isunity(&self) -> bool {
         let one = FP8::new_int(1);
-        return self.a.equals(&one) && self.b.iszilch();
+        self.a.equals(&one) && self.b.iszilch()
     }
 
     /* test is w real? That is in a+ib test b is zero */
     pub fn isreal(&mut self) -> bool {
-        return self.b.iszilch();
+        self.b.iszilch()
     }
     /* extract real part a */
     pub fn real(&self) -> FP8 {
-        let f = FP8::new_copy(&self.a);
-        return f;
+        FP8::new_copy(&self.a)
     }
 
     pub fn geta(&self) -> FP8 {
-        let f = FP8::new_copy(&self.a);
-        return f;
+        FP8::new_copy(&self.a)
     }
     /* extract imaginary part b */
     pub fn getb(&self) -> FP8 {
-        let f = FP8::new_copy(&self.b);
-        return f;
+        FP8::new_copy(&self.b)
     }
 
     /* test self=x */
     pub fn equals(&self, x: &FP16) -> bool {
-        return self.a.equals(&x.a) && self.b.equals(&x.b);
+        self.a.equals(&x.a) && self.b.equals(&x.b)
     }
     /* copy self=x */
     pub fn copy(&mut self, x: &FP16) {
@@ -338,7 +335,7 @@ impl FP16 {
 
     /* output to hex string */
     pub fn tostring(&self) -> String {
-        return format!("[{},{}]", self.a.tostring(), self.b.tostring());
+        format!("[{},{}]", self.a.tostring(), self.b.tostring())
     }
 
     /* self=1/self */
@@ -410,7 +407,7 @@ impl FP16 {
             w.sqr();
         }
         r.reduce();
-        return r;
+        r
     }
 
     /* XTR xtr_a function */

--- a/rust/fp2.rs
+++ b/rust/fp2.rs
@@ -55,53 +55,53 @@ impl FP2 {
         let mut f = FP2::new();
         f.a.copy(&FP::new_int(a));
         f.b.zero();
-        return f;
+        f
     }
 
     pub fn new_ints(a: isize, b: isize) -> FP2 {
         let mut f = FP2::new();
         f.a.copy(&FP::new_int(a));
         f.b.copy(&FP::new_int(b));
-        return f;
+        f
     }
 
     pub fn new_copy(x: &FP2) -> FP2 {
         let mut f = FP2::new();
         f.a.copy(&x.a);
         f.b.copy(&x.b);
-        return f;
+        f
     }
 
     pub fn new_fps(c: &FP, d: &FP) -> FP2 {
         let mut f = FP2::new();
         f.a.copy(c);
         f.b.copy(d);
-        return f;
+        f
     }
 
     pub fn new_bigs(c: &BIG, d: &BIG) -> FP2 {
         let mut f = FP2::new();
         f.a.copy(&FP::new_big(c));
         f.b.copy(&FP::new_big(d));
-        return f;
+        f
     }
 
     pub fn new_fp(c: &FP) -> FP2 {
         let mut f = FP2::new();
         f.a.copy(c);
         f.b.zero();
-        return f;
+        f
     }
 
     pub fn new_big(c: &BIG) -> FP2 {
         let mut f = FP2::new();
         f.a.copy(&FP::new_big(c));
         f.b.zero();
-        return f;
+        f
     }
 
     pub fn new_rand(rng: &mut RAND) -> FP2 {
-        return FP2::new_fps(&FP::new_rand(rng),&FP::new_rand(rng));
+        FP2::new_fps(&FP::new_rand(rng),&FP::new_rand(rng))
     }
 
     /* reduce components mod Modulus */
@@ -118,7 +118,7 @@ impl FP2 {
 
     /* test self=0 ? */
     pub fn iszilch(&self) -> bool {
-        return self.a.iszilch() && self.b.iszilch();
+        self.a.iszilch() && self.b.iszilch()
     }
 
     pub fn islarger(&self) -> isize {
@@ -129,7 +129,7 @@ impl FP2 {
         if cmp!=0 {
             return cmp;
         }
-        return self.a.islarger()
+        self.a.islarger()
     }
 
     pub fn tobytes(&self,bf: &mut [u8]) {
@@ -156,7 +156,7 @@ impl FP2 {
             t[i]=bf[i+MB];
         }
         let ta=FP::frombytes(&t);
-        return FP2::new_fps(&ta,&tb);
+        FP2::new_fps(&ta,&tb)
     }
 
     pub fn cmove(&mut self, g: &FP2, d: isize) {
@@ -167,34 +167,34 @@ impl FP2 {
     /* test self=1 ? */
     pub fn isunity(&self) -> bool {
         let one = FP::new_int(1);
-        return self.a.equals(&one) && self.b.iszilch();
+        self.a.equals(&one) && self.b.iszilch()
     }
 
     /* test self=x */
     pub fn equals(&self, x: &FP2) -> bool {
-        return self.a.equals(&x.a) && self.b.equals(&x.b);
+        self.a.equals(&x.a) && self.b.equals(&x.b)
     }
 
     /* extract a */
     #[allow(non_snake_case)]
     pub fn getA(&mut self) -> FP {
-        return self.a;
+        self.a
     }
 
     /* extract b */
     #[allow(non_snake_case)]
     pub fn getB(&mut self) -> FP {
-        return self.b;
+        self.b
     }
 
     /* extract a */
     pub fn geta(&mut self) -> BIG {
-        return self.a.redc();
+        self.a.redc()
     }
 
     /* extract b */
     pub fn getb(&mut self) -> BIG {
-        return self.b.redc();
+        self.b.redc()
     }
 
     /* copy self=x */
@@ -226,11 +226,11 @@ impl FP2 {
         if fp::BIG_ENDIAN_SIGN {
             let u=self.b.iszilch() as isize;
 	        p2^=(p1^p2)&u;
-	        return p2;
+	        p2
         } else {
             let u=self.a.iszilch() as isize;
 	        p1^=(p1^p2)&u;
-	        return p1;
+	        p1
         }
     }
 
@@ -377,7 +377,7 @@ impl FP2 {
         let mut c=FP2::new_copy(self);
         c.conj();
         c.mul(self);
-        return c.getA().qr(h);
+        c.getA().qr(h)
     }
 
     /* sqrt(a+ib) = sqrt(a+sqrt(a*a-n*b*b)/2)+ib/(2*sqrt(a+sqrt(a*a-n*b*b)/2)) */
@@ -447,7 +447,7 @@ impl FP2 {
 
     /* output to hex string */
     pub fn tostring(&self) -> String {
-        return format!("[{},{}]", self.a.tostring(), self.b.tostring());
+        format!("[{},{}]", self.a.tostring(), self.b.tostring())
     }
 
     /* self=1/self */

--- a/rust/fp24.rs
+++ b/rust/fp24.rs
@@ -66,7 +66,7 @@ impl FP24 {
     }
 
     pub fn gettype(&self) -> usize {
-        return self.stype;
+        self.stype
     }
 
     pub fn new_int(a: isize) -> FP24 {
@@ -79,7 +79,7 @@ impl FP24 {
         } else {
             f.stype = SPARSEST;
         }
-        return f;
+        f
     }
 
     pub fn new_copy(x: &FP24) -> FP24 {
@@ -88,7 +88,7 @@ impl FP24 {
         f.b.copy(&x.b);
         f.c.copy(&x.c);
         f.stype = x.stype;
-        return f;
+        f
     }
 
     pub fn new_fp8s(d: &FP8, e: &FP8, f: &FP8) -> FP24 {
@@ -97,7 +97,7 @@ impl FP24 {
         g.b.copy(e);
         g.c.copy(f);
         g.stype = DENSE;
-        return g;
+        g
     }
 
     pub fn new_fp8(d: &FP8) -> FP24 {
@@ -106,7 +106,7 @@ impl FP24 {
         g.b.zero();
         g.c.zero();
         g.stype = SPARSEST;
-        return g;
+        g
     }
 
     /* reduce components mod Modulus */
@@ -125,7 +125,7 @@ impl FP24 {
 
     /* test self=0 ? */
     pub fn iszilch(&self) -> bool {
-        return self.a.iszilch() && self.b.iszilch() && self.c.iszilch();
+        self.a.iszilch() && self.b.iszilch() && self.c.iszilch()
     }
 
     /* Conditional move of g to self dependant on d */
@@ -142,7 +142,7 @@ impl FP24 {
     fn teq(b: i32, c: i32) -> isize {
         let mut x = b ^ c;
         x -= 1; // if x=0, x now -1
-        return ((x >> 31) & 1) as isize;
+        ((x >> 31) & 1) as isize
     }
 
     /* Constant time select from pre-computed table */
@@ -169,28 +169,28 @@ impl FP24 {
     /* test self=1 ? */
     pub fn isunity(&self) -> bool {
         let one = FP8::new_int(1);
-        return self.a.equals(&one) && self.b.iszilch() && self.c.iszilch();
+        self.a.equals(&one) && self.b.iszilch() && self.c.iszilch()
     }
 
     /* test self=x */
     pub fn equals(&self, x: &FP24) -> bool {
-        return self.a.equals(&x.a) && self.b.equals(&x.b) && self.c.equals(&x.c);
+        self.a.equals(&x.a) && self.b.equals(&x.b) && self.c.equals(&x.c)
     }
 
     pub fn geta(&mut self) -> FP8 {
-        return self.a;
+        self.a
         //        let f = FP8::new_copy(&self.a);
         //        return f;
     }
 
     pub fn getb(&mut self) -> FP8 {
-        return self.b;
+        self.b
         //	let f = FP8::new_copy(&self.b);
         //        return f;
     }
 
     pub fn getc(&mut self) -> FP8 {
-        return self.c;
+        self.c
         //        let f = FP8::new_copy(&self.c);
         //        return f;
     }
@@ -872,7 +872,7 @@ impl FP24 {
         t.copy(&self.a);
         t.imul(3);
         t.reduce();
-        return t;
+        t
     }
 
     /* convert from byte array to FP24 */
@@ -891,7 +891,7 @@ impl FP24 {
 		    t[i]=w[i+2*MB];
 	    }
         let a=FP8::frombytes(&t);
-	    return FP24::new_fp8s(&a,&b,&c);
+        FP24::new_fp8s(&a,&b,&c)
     }
 
     /* convert this to byte array */
@@ -915,12 +915,12 @@ impl FP24 {
 
     /* output to hex string */
     pub fn tostring(&self) -> String {
-        return format!(
+        format!(
             "[{},{},{}]",
             self.a.tostring(),
             self.b.tostring(),
             self.c.tostring()
-        );
+        )
     }
 
 /* Note this is simple square and multiply, so not side-channel safe */
@@ -954,7 +954,7 @@ impl FP24 {
         }
 
         w.reduce();
-        return w;
+        w
     }
 
     /* constant time powering by small integer of max length bts */
@@ -1179,6 +1179,6 @@ impl FP24 {
         p.cmove(&r, pb2);
 
         p.reduce();
-        return p;
+        p
     }
 }

--- a/rust/fp4.rs
+++ b/rust/fp4.rs
@@ -570,46 +570,42 @@ impl FP4 {
                     cumv.copy(&cv);
                     cv.copy(&cu);
                     cu.copy(&t);
+                } else if d.parity() == 0 {
+                    d.fshr(1);
+                    r.copy(&cum2v);
+                    r.conj();
+                    t.copy(&cumv);
+                    t.xtr_a(&cu, &cv, &r);
+                    cum2v.copy(&cumv);
+                    cum2v.xtr_d();
+                    cumv.copy(&t);
+                    cu.xtr_d();
+                } else if e.parity() == 1 {
+                    d.sub(&e);
+                    d.norm();
+                    d.fshr(1);
+                    t.copy(&cv);
+                    t.xtr_a(&cu, &cumv, &cum2v);
+                    cu.xtr_d();
+                    cum2v.copy(&cv);
+                    cum2v.xtr_d();
+                    cum2v.conj();
+                    cv.copy(&t);
                 } else {
-                    if d.parity() == 0 {
-                        d.fshr(1);
-                        r.copy(&cum2v);
-                        r.conj();
-                        t.copy(&cumv);
-                        t.xtr_a(&cu, &cv, &r);
-                        cum2v.copy(&cumv);
-                        cum2v.xtr_d();
-                        cumv.copy(&t);
-                        cu.xtr_d();
-                    } else {
-                        if e.parity() == 1 {
-                            d.sub(&e);
-                            d.norm();
-                            d.fshr(1);
-                            t.copy(&cv);
-                            t.xtr_a(&cu, &cumv, &cum2v);
-                            cu.xtr_d();
-                            cum2v.copy(&cv);
-                            cum2v.xtr_d();
-                            cum2v.conj();
-                            cv.copy(&t);
-                        } else {
-                            w.copy(&d);
-                            d.copy(&e);
-                            d.fshr(1);
-                            e.copy(&w);
-                            t.copy(&cumv);
-                            t.xtr_d();
-                            cumv.copy(&cum2v);
-                            cumv.conj();
-                            cum2v.copy(&t);
-                            cum2v.conj();
-                            t.copy(&cv);
-                            t.xtr_d();
-                            cv.copy(&cu);
-                            cu.copy(&t);
-                        }
-                    }
+                    w.copy(&d);
+                    d.copy(&e);
+                    d.fshr(1);
+                    e.copy(&w);
+                    t.copy(&cumv);
+                    t.xtr_d();
+                    cumv.copy(&cum2v);
+                    cumv.conj();
+                    cum2v.copy(&t);
+                    cum2v.conj();
+                    t.copy(&cv);
+                    t.xtr_d();
+                    cv.copy(&cu);
+                    cu.copy(&t);
                 }
             }
             if BIG::comp(&d, &e) < 0 {
@@ -624,51 +620,47 @@ impl FP4 {
                     cum2v.copy(&cumv);
                     cumv.copy(&cu);
                     cu.copy(&t);
+                } else if e.parity() == 0 {
+                    w.copy(&d);
+                    d.copy(&e);
+                    d.fshr(1);
+                    e.copy(&w);
+                    t.copy(&cumv);
+                    t.xtr_d();
+                    cumv.copy(&cum2v);
+                    cumv.conj();
+                    cum2v.copy(&t);
+                    cum2v.conj();
+                    t.copy(&cv);
+                    t.xtr_d();
+                    cv.copy(&cu);
+                    cu.copy(&t);
+                } else if d.parity() == 1 {
+                    w.copy(&e);
+                    e.copy(&d);
+                    w.sub(&d);
+                    w.norm();
+                    d.copy(&w);
+                    d.fshr(1);
+                    t.copy(&cv);
+                    t.xtr_a(&cu, &cumv, &cum2v);
+                    cumv.conj();
+                    cum2v.copy(&cu);
+                    cum2v.xtr_d();
+                    cum2v.conj();
+                    cu.copy(&cv);
+                    cu.xtr_d();
+                    cv.copy(&t);
                 } else {
-                    if e.parity() == 0 {
-                        w.copy(&d);
-                        d.copy(&e);
-                        d.fshr(1);
-                        e.copy(&w);
-                        t.copy(&cumv);
-                        t.xtr_d();
-                        cumv.copy(&cum2v);
-                        cumv.conj();
-                        cum2v.copy(&t);
-                        cum2v.conj();
-                        t.copy(&cv);
-                        t.xtr_d();
-                        cv.copy(&cu);
-                        cu.copy(&t);
-                    } else {
-                        if d.parity() == 1 {
-                            w.copy(&e);
-                            e.copy(&d);
-                            w.sub(&d);
-                            w.norm();
-                            d.copy(&w);
-                            d.fshr(1);
-                            t.copy(&cv);
-                            t.xtr_a(&cu, &cumv, &cum2v);
-                            cumv.conj();
-                            cum2v.copy(&cu);
-                            cum2v.xtr_d();
-                            cum2v.conj();
-                            cu.copy(&cv);
-                            cu.xtr_d();
-                            cv.copy(&t);
-                        } else {
-                            d.fshr(1);
-                            r.copy(&cum2v);
-                            r.conj();
-                            t.copy(&cumv);
-                            t.xtr_a(&cu, &cv, &r);
-                            cum2v.copy(&cumv);
-                            cum2v.xtr_d();
-                            cumv.copy(&t);
-                            cu.xtr_d();
-                        }
-                    }
+                    d.fshr(1);
+                    r.copy(&cum2v);
+                    r.conj();
+                    t.copy(&cumv);
+                    t.xtr_a(&cu, &cv, &r);
+                    cum2v.copy(&cumv);
+                    cum2v.xtr_d();
+                    cumv.copy(&t);
+                    cu.xtr_d();
                 }
             }
         }

--- a/rust/fp4.rs
+++ b/rust/fp4.rs
@@ -55,46 +55,46 @@ impl FP4 {
         let mut f = FP4::new();
         f.a.copy(&FP2::new_int(a));
         f.b.zero();
-        return f;
+        f
     }
 
     pub fn new_ints(a: isize,b: isize) -> FP4 {
         let mut f = FP4::new();
         f.a.copy(&FP2::new_int(a));
         f.b.copy(&FP2::new_int(b));
-        return f;
+        f
     }
 
     pub fn new_copy(x: &FP4) -> FP4 {
         let mut f = FP4::new();
         f.a.copy(&x.a);
         f.b.copy(&x.b);
-        return f;
+        f
     }
 
     pub fn new_fp2s(c: &FP2, d: &FP2) -> FP4 {
         let mut f = FP4::new();
         f.a.copy(c);
         f.b.copy(d);
-        return f;
+        f
     }
 
     pub fn new_fp2(c: &FP2) -> FP4 {
         let mut f = FP4::new();
         f.a.copy(c);
         f.b.zero();
-        return f;
+        f
     }
 
     pub fn new_fp(c: &FP) -> FP4 {
         let mut f = FP4::new();
         f.a.set_fp(c);
         f.b.zero();
-        return f;
+        f
     }
 
     pub fn new_rand(rng: &mut RAND) -> FP4 {
-        return FP4::new_fp2s(&FP2::new_rand(rng),&FP2::new_rand(rng));
+       FP4::new_fp2s(&FP2::new_rand(rng),&FP2::new_rand(rng))
     }
 
     pub fn set_fp2s(&mut self, c: &FP2, d: &FP2) {
@@ -136,18 +136,20 @@ impl FP4 {
 
     /* test self=0 ? */
     pub fn iszilch(&self) -> bool {
-        return self.a.iszilch() && self.b.iszilch();
+        self.a.iszilch() && self.b.iszilch()
     }
 
     pub fn islarger(&self) -> isize {
         if self.iszilch() {
-            return 0;
+            0
+        } else {
+            let cmp=self.b.islarger();
+            if cmp!=0 {
+                cmp
+            } else {
+                self.a.islarger()
+            }
         }
-        let cmp=self.b.islarger();
-        if cmp!=0 {
-            return cmp;
-        }
-        return self.a.islarger()
     }
 
     pub fn tobytes(&self,bf: &mut [u8]) {
@@ -174,7 +176,7 @@ impl FP4 {
             t[i]=bf[i+MB];
         }
         let ta=FP2::frombytes(&t);
-        return FP4::new_fp2s(&ta,&tb);
+        FP4::new_fp2s(&ta,&tb)
     }
 
 
@@ -182,32 +184,29 @@ impl FP4 {
     /* test self=1 ? */
     pub fn isunity(&self) -> bool {
         let one = FP2::new_int(1);
-        return self.a.equals(&one) && self.b.iszilch();
+        self.a.equals(&one) && self.b.iszilch()
     }
 
     /* test is w real? That is in a+ib test b is zero */
     pub fn isreal(&mut self) -> bool {
-        return self.b.iszilch();
+        self.b.iszilch()
     }
     /* extract real part a */
     pub fn real(&self) -> FP2 {
-        let f = FP2::new_copy(&self.a);
-        return f;
+        FP2::new_copy(&self.a)
     }
 
     pub fn geta(&self) -> FP2 {
-        let f = FP2::new_copy(&self.a);
-        return f;
+        FP2::new_copy(&self.a)
     }
     /* extract imaginary part b */
     pub fn getb(&self) -> FP2 {
-        let f = FP2::new_copy(&self.b);
-        return f;
+        FP2::new_copy(&self.b)
     }
 
     /* test self=x */
     pub fn equals(&self, x: &FP4) -> bool {
-        return self.a.equals(&x.a) && self.b.equals(&x.b);
+        self.a.equals(&x.a) && self.b.equals(&x.b)
     }
     /* copy self=x */
     pub fn copy(&mut self, x: &FP4) {
@@ -233,11 +232,11 @@ impl FP4 {
         if fp::BIG_ENDIAN_SIGN {
             let u=self.b.iszilch() as isize;
 	        p2^=(p1^p2)&u;
-	        return p2;
+	        p2
         } else {
             let u=self.a.iszilch() as isize;
 	        p1^=(p1^p2)&u;
-	        return p1;
+	        p1
         }
     }
 
@@ -387,7 +386,7 @@ impl FP4 {
 
     /* output to hex string */
     pub fn tostring(&self) -> String {
-        return format!("[{},{}]", self.a.tostring(), self.b.tostring());
+        format!("[{},{}]", self.a.tostring(), self.b.tostring())
     }
 
     /* self=1/self */
@@ -449,7 +448,7 @@ impl FP4 {
             w.sqr();
         }
         r.reduce();
-        return r;
+        r
     }
 */
     /* XTR xtr_a function */
@@ -528,7 +527,7 @@ impl FP4 {
             r.copy(&b)
         }
         r.reduce();
-        return r;
+        r
     }
 
     /* r=ck^a.cl^n using XTR double exponentiation method on traces of FP12s. See Stam thesis. */
@@ -679,7 +678,7 @@ impl FP4 {
             r.xtr_d()
         }
         r = r.xtr_pow(&d);
-        return r;
+        r
     }
 
     /* this/=2 */
@@ -726,7 +725,7 @@ impl FP4 {
         let mut c=FP4::new_copy(self);
         c.conj();
         c.mul(self);
-        return c.geta().qr(h);
+        c.geta().qr(h)
     }
 
     // sqrt(a+ib) = sqrt(a+sqrt(a*a-n*b*b)/2)+ib/(2*sqrt(a+sqrt(a*a-n*b*b)/2)) 

--- a/rust/fp48.rs
+++ b/rust/fp48.rs
@@ -66,7 +66,7 @@ impl FP48 {
     }
 
     pub fn gettype(&self) -> usize {
-        return self.stype;
+        self.stype
     }
 
     pub fn new_int(a: isize) -> FP48 {
@@ -79,7 +79,7 @@ impl FP48 {
         } else {
             f.stype = SPARSEST;
         }
-        return f;
+        f
     }
 
     pub fn new_copy(x: &FP48) -> FP48 {
@@ -88,7 +88,7 @@ impl FP48 {
         f.b.copy(&x.b);
         f.c.copy(&x.c);
         f.stype = x.stype;
-        return f;
+        f
     }
 
     pub fn new_fp16s(d: &FP16, e: &FP16, f: &FP16) -> FP48 {
@@ -97,7 +97,7 @@ impl FP48 {
         g.b.copy(e);
         g.c.copy(f);
         g.stype = DENSE;
-        return g;
+        g
     }
 
     pub fn new_fp16(d: &FP16) -> FP48 {
@@ -106,7 +106,7 @@ impl FP48 {
         g.b.zero();
         g.c.zero();
         g.stype = SPARSEST;
-        return g;
+        g
     }
 
     /* reduce components mod Modulus */
@@ -125,7 +125,7 @@ impl FP48 {
 
     /* test self=0 ? */
     pub fn iszilch(&self) -> bool {
-        return self.a.iszilch() && self.b.iszilch() && self.c.iszilch();
+        self.a.iszilch() && self.b.iszilch() && self.c.iszilch()
     }
 
     /* Conditional move of g to self dependant on d */
@@ -142,7 +142,7 @@ impl FP48 {
     fn teq(b: i32, c: i32) -> isize {
         let mut x = b ^ c;
         x -= 1; // if x=0, x now -1
-        return ((x >> 31) & 1) as isize;
+        ((x >> 31) & 1) as isize
     }
 
     /* Constant time select from pre-computed table */
@@ -169,28 +169,28 @@ impl FP48 {
     /* test self=1 ? */
     pub fn isunity(&self) -> bool {
         let one = FP16::new_int(1);
-        return self.a.equals(&one) && self.b.iszilch() && self.c.iszilch();
+        self.a.equals(&one) && self.b.iszilch() && self.c.iszilch()
     }
 
     /* test self=x */
     pub fn equals(&self, x: &FP48) -> bool {
-        return self.a.equals(&x.a) && self.b.equals(&x.b) && self.c.equals(&x.c);
+        self.a.equals(&x.a) && self.b.equals(&x.b) && self.c.equals(&x.c)
     }
 
     pub fn geta(&mut self) -> FP16 {
-        return self.a;
+        self.a
         //        let f = FP16::new_copy(&self.a);
         //        return f;
     }
 
     pub fn getb(&mut self) -> FP16 {
-        return self.b;
+        self.b
         //        let f = FP16::new_copy(&self.b);
         //        return f;
     }
 
     pub fn getc(&mut self) -> FP16 {
-        return self.c;
+        self.c
         //        let f = FP16::new_copy(&self.c);
         //        return f;
     }
@@ -876,7 +876,7 @@ impl FP48 {
         t.copy(&self.a);
         t.imul(3);
         t.reduce();
-        return t;
+        t
     }
 
     /* convert from byte array to FP48 */
@@ -895,7 +895,7 @@ impl FP48 {
 		    t[i]=w[i+2*MB];
 	    }
         let a=FP16::frombytes(&t);
-	    return FP48::new_fp16s(&a,&b,&c);
+	FP48::new_fp16s(&a,&b,&c)
     }
 
     /* convert this to byte array */
@@ -919,12 +919,12 @@ impl FP48 {
 
     /* output to hex string */
     pub fn tostring(&self) -> String {
-        return format!(
+        format!(
             "[{},{},{}]",
             self.a.tostring(),
             self.b.tostring(),
             self.c.tostring()
-        );
+        )
     }
 
 /* Note this is simple square and multiply, so not side-channel safe */
@@ -958,7 +958,7 @@ impl FP48 {
         }
 
         w.reduce();
-        return w;
+        w
     }
 
     /* constant time powering by small integer of max length bts */
@@ -1313,6 +1313,6 @@ impl FP48 {
         p.cmove(&r, pb4);
 
         p.reduce();
-        return p;
+        p
     }
 }

--- a/rust/fp8.rs
+++ b/rust/fp8.rs
@@ -57,46 +57,46 @@ impl FP8 {
         let mut f = FP8::new();
         f.a.copy(&FP4::new_int(a));
         f.b.zero();
-        return f;
+        f
     }
 
     pub fn new_ints(a: isize,b: isize) -> FP8 {
         let mut f = FP8::new();
         f.a.copy(&FP4::new_int(a));
         f.b.copy(&FP4::new_int(b));
-        return f;
+        f
     }
 
     pub fn new_copy(x: &FP8) -> FP8 {
         let mut f = FP8::new();
         f.a.copy(&x.a);
         f.b.copy(&x.b);
-        return f;
+        f
     }
 
     pub fn new_fp4s(c: &FP4, d: &FP4) -> FP8 {
         let mut f = FP8::new();
         f.a.copy(c);
         f.b.copy(d);
-        return f;
+        f
     }
 
     pub fn new_fp4(c: &FP4) -> FP8 {
         let mut f = FP8::new();
         f.a.copy(c);
         f.b.zero();
-        return f;
+        f
     }
 
     pub fn new_fp(c: &FP) -> FP8 {
         let mut f = FP8::new();
         f.a.set_fp(c);
         f.b.zero();
-        return f;
+        f
     }
 
     pub fn new_rand(rng: &mut RAND) -> FP8 {
-        return FP8::new_fp4s(&FP4::new_rand(rng),&FP4::new_rand(rng));
+        FP8::new_fp4s(&FP4::new_rand(rng),&FP4::new_rand(rng))
     }
 
     pub fn set_fp4s(&mut self, c: &FP4, d: &FP4) {
@@ -133,7 +133,7 @@ impl FP8 {
 
     /* test self=0 ? */
     pub fn iszilch(&self) -> bool {
-        return self.a.iszilch() && self.b.iszilch();
+        self.a.iszilch() && self.b.iszilch()
     }
 
     pub fn islarger(&self) -> isize {
@@ -144,7 +144,7 @@ impl FP8 {
         if cmp!=0 {
             return cmp;
         }
-        return self.a.islarger()
+        self.a.islarger()
     }
 
     pub fn tobytes(&self,bf: &mut [u8]) {
@@ -171,38 +171,35 @@ impl FP8 {
             t[i]=bf[i+MB];
         }
         let ta=FP4::frombytes(&t);
-        return FP8::new_fp4s(&ta,&tb);
+        FP8::new_fp4s(&ta,&tb)
     }
 
     /* test self=1 ? */
     pub fn isunity(&self) -> bool {
         let one = FP4::new_int(1);
-        return self.a.equals(&one) && self.b.iszilch();
+        self.a.equals(&one) && self.b.iszilch()
     }
 
     /* test is w real? That is in a+ib test b is zero */
     pub fn isreal(&mut self) -> bool {
-        return self.b.iszilch();
+        self.b.iszilch()
     }
     /* extract real part a */
     pub fn real(&self) -> FP4 {
-        let f = FP4::new_copy(&self.a);
-        return f;
+        FP4::new_copy(&self.a)
     }
 
     pub fn geta(&self) -> FP4 {
-        let f = FP4::new_copy(&self.a);
-        return f;
+        FP4::new_copy(&self.a)
     }
     /* extract imaginary part b */
     pub fn getb(&self) -> FP4 {
-        let f = FP4::new_copy(&self.b);
-        return f;
+        FP4::new_copy(&self.b)
     }
 
     /* test self=x */
     pub fn equals(&self, x: &FP8) -> bool {
-        return self.a.equals(&x.a) && self.b.equals(&x.b);
+        self.a.equals(&x.a) && self.b.equals(&x.b)
     }
     /* copy self=x */
     pub fn copy(&mut self, x: &FP8) {
@@ -389,7 +386,7 @@ impl FP8 {
 
     /* output to hex string */
     pub fn tostring(&self) -> String {
-        return format!("[{},{}]", self.a.tostring(), self.b.tostring());
+        format!("[{},{}]", self.a.tostring(), self.b.tostring())
     }
 
     /* self=1/self */

--- a/rust/gcm.rs
+++ b/rust/gcm.rs
@@ -42,10 +42,10 @@ pub struct GCM {
 impl GCM {
     fn pack(b: [u8; 4]) -> u32 {
         /* pack bytes into a 32-bit Word */
-        ((((b[0]) & 0xff) as u32) << 24)
-            | ((((b[1]) & 0xff) as u32) << 16)
-            | ((((b[2]) & 0xff) as u32) << 8)
-            | (((b[3]) & 0xff) as u32)
+        ((b[0] as u32) << 24)
+            | ((b[1] as u32) << 16)
+            | ((b[2] as u32) << 8)
+            | (b[3] as u32)
     }
 
     fn unpack(a: u32) -> [u8; 4] {

--- a/rust/gcm.rs
+++ b/rust/gcm.rs
@@ -42,21 +42,20 @@ pub struct GCM {
 impl GCM {
     fn pack(b: [u8; 4]) -> u32 {
         /* pack bytes into a 32-bit Word */
-        return ((((b[0]) & 0xff) as u32) << 24)
+        ((((b[0]) & 0xff) as u32) << 24)
             | ((((b[1]) & 0xff) as u32) << 16)
             | ((((b[2]) & 0xff) as u32) << 8)
-            | (((b[3]) & 0xff) as u32);
+            | (((b[3]) & 0xff) as u32)
     }
 
     fn unpack(a: u32) -> [u8; 4] {
         /* unpack bytes from a word */
-        let b: [u8; 4] = [
+        [
             ((a >> 24) & 0xff) as u8,
             ((a >> 16) & 0xff) as u8,
             ((a >> 8) & 0xff) as u8,
             (a & 0xff) as u8,
-        ];
-        return b;
+        ]
     }
 
     fn precompute(&mut self, h: &[u8]) {
@@ -168,7 +167,7 @@ impl GCM {
         if len % 16 != 0 {
             self.status = GCM_NOT_ACCEPTING_MORE
         }
-        return true;
+        true
     }
 
     /* Initialize GCM mode */
@@ -257,7 +256,7 @@ impl GCM {
         if len % 16 != 0 {
             self.status = GCM_ACCEPTING_CIPHER
         }
-        return true;
+        true
     }
 
     /* Add Plaintext - included and encrypted */
@@ -308,7 +307,7 @@ impl GCM {
         if len % 16 != 0 {
             self.status = GCM_NOT_ACCEPTING_MORE
         }
-        return true;
+        true
     }
 
     /* Add Ciphertext - decrypts to plaintext */
@@ -360,7 +359,7 @@ impl GCM {
         if len % 16 != 0 {
             self.status = GCM_NOT_ACCEPTING_MORE
         }
-        return true;
+        true
     }
 
     /* Finish and extract Tag */

--- a/rust/hash256.rs
+++ b/rust/hash256.rs
@@ -167,7 +167,7 @@ impl HASH256 {
         /* process the next message byte */
         let cnt = ((self.length[0] / 32) % 16) as usize;
         self.w[cnt] <<= 8;
-        self.w[cnt] |= (byt & 0xFF) as u32;
+        self.w[cnt] |= byt as u32;
         self.length[0] += 8;
         if self.length[0] == 0 {
             self.length[1] += 1;

--- a/rust/hash256.rs
+++ b/rust/hash256.rs
@@ -45,33 +45,33 @@ pub struct HASH256 {
 
 impl HASH256 {
     fn s(n: u32, x: u32) -> u32 {
-        return ((x) >> n) | ((x) << (32 - n));
+        ((x) >> n) | ((x) << (32 - n))
     }
     fn r(n: u32, x: u32) -> u32 {
-        return (x) >> n;
+        (x) >> n
     }
 
     fn ch(x: u32, y: u32, z: u32) -> u32 {
-        return (x & y) ^ (!(x) & z);
+        (x & y) ^ (!(x) & z)
     }
 
     fn maj(x: u32, y: u32, z: u32) -> u32 {
-        return (x & y) ^ (x & z) ^ (y & z);
+        (x & y) ^ (x & z) ^ (y & z)
     }
     fn sig0(x: u32) -> u32 {
-        return HASH256::s(2, x) ^ HASH256::s(13, x) ^ HASH256::s(22, x);
+        HASH256::s(2, x) ^ HASH256::s(13, x) ^ HASH256::s(22, x)
     }
 
     fn sig1(x: u32) -> u32 {
-        return HASH256::s(6, x) ^ HASH256::s(11, x) ^ HASH256::s(25, x);
+        HASH256::s(6, x) ^ HASH256::s(11, x) ^ HASH256::s(25, x)
     }
 
     fn theta0(x: u32) -> u32 {
-        return HASH256::s(7, x) ^ HASH256::s(18, x) ^ HASH256::r(3, x);
+        HASH256::s(7, x) ^ HASH256::s(18, x) ^ HASH256::r(3, x)
     }
 
     fn theta1(x: u32) -> u32 {
-        return HASH256::s(17, x) ^ HASH256::s(19, x) ^ HASH256::r(10, x);
+        HASH256::s(17, x) ^ HASH256::s(19, x) ^ HASH256::r(10, x)
     }
 
     fn transform(&mut self) {
@@ -142,7 +142,7 @@ impl HASH256 {
             w: [0; 64],
         };
         nh.init();
-        return nh;
+        nh
     }
 
     pub fn new_copy(hh: &HASH256) -> HASH256 {
@@ -159,7 +159,7 @@ impl HASH256 {
         for i in 0..8 {
             nh.h[i] = hh.h[i];
         }
-        return nh;        
+        nh        
     }
 
     /* process a single byte */
@@ -212,12 +212,12 @@ impl HASH256 {
             digest[i] = ((self.h[i / 4] >> (8 * (3 - i % 4))) & 0xff) as u8;
         }
         self.init();
-        return digest;
+        digest
     }
 
     pub fn continuing_hash(&self) -> [u8; 32] {
         let mut sh=HASH256::new_copy(self);
-        return sh.hash();
+        sh.hash()
     }
 }
 

--- a/rust/hash384.rs
+++ b/rust/hash384.rs
@@ -117,34 +117,34 @@ pub struct HASH384 {
 
 impl HASH384 {
     fn s(n: u64, x: u64) -> u64 {
-        return ((x) >> n) | ((x) << (64 - n));
+        ((x) >> n) | ((x) << (64 - n))
     }
     fn r(n: u64, x: u64) -> u64 {
-        return (x) >> n;
+        (x) >> n
     }
 
     fn ch(x: u64, y: u64, z: u64) -> u64 {
-        return (x & y) ^ (!(x) & z);
+        (x & y) ^ (!(x) & z)
     }
 
     fn maj(x: u64, y: u64, z: u64) -> u64 {
-        return (x & y) ^ (x & z) ^ (y & z);
+        (x & y) ^ (x & z) ^ (y & z)
     }
 
     fn sig0(x: u64) -> u64 {
-        return HASH384::s(28, x) ^ HASH384::s(34, x) ^ HASH384::s(39, x);
+        HASH384::s(28, x) ^ HASH384::s(34, x) ^ HASH384::s(39, x)
     }
 
     fn sig1(x: u64) -> u64 {
-        return HASH384::s(14, x) ^ HASH384::s(18, x) ^ HASH384::s(41, x);
+        HASH384::s(14, x) ^ HASH384::s(18, x) ^ HASH384::s(41, x)
     }
 
     fn theta0(x: u64) -> u64 {
-        return HASH384::s(1, x) ^ HASH384::s(8, x) ^ HASH384::r(7, x);
+        HASH384::s(1, x) ^ HASH384::s(8, x) ^ HASH384::r(7, x)
     }
 
     fn theta1(x: u64) -> u64 {
-        return HASH384::s(19, x) ^ HASH384::s(61, x) ^ HASH384::r(6, x);
+        HASH384::s(19, x) ^ HASH384::s(61, x) ^ HASH384::r(6, x)
     }
 
     fn transform(&mut self) {
@@ -215,7 +215,7 @@ impl HASH384 {
             w: [0; 80],
         };
         nh.init();
-        return nh;
+        nh
     }
 
     pub fn new_copy(hh: &HASH384) -> HASH384 {
@@ -232,7 +232,7 @@ impl HASH384 {
         for i in 0..8 {
             nh.h[i] = hh.h[i];
         }
-        return nh;        
+        nh        
     }
 
     /* process a single byte */
@@ -285,11 +285,11 @@ impl HASH384 {
             digest[i] = ((self.h[i / 8] >> (8 * (7 - i % 8))) & 0xff) as u8;
         }
         self.init();
-        return digest;
+        digest
     }
     pub fn continuing_hash(&self) -> [u8; 48] {
         let mut sh=HASH384::new_copy(self);
-        return sh.hash();
+        sh.hash()
     }
 }
 

--- a/rust/hash384.rs
+++ b/rust/hash384.rs
@@ -240,7 +240,7 @@ impl HASH384 {
         /* process the next message byte */
         let cnt = ((self.length[0] / 64) % 16) as usize;
         self.w[cnt] <<= 8;
-        self.w[cnt] |= (byt & 0xFF) as u64;
+        self.w[cnt] |= byt as u64;
         self.length[0] += 8;
         if self.length[0] == 0 {
             self.length[1] += 1;

--- a/rust/hash512.rs
+++ b/rust/hash512.rs
@@ -240,7 +240,7 @@ impl HASH512 {
         /* process the next message byte */
         let cnt = ((self.length[0] / 64) % 16) as usize;
         self.w[cnt] <<= 8;
-        self.w[cnt] |= (byt & 0xFF) as u64;
+        self.w[cnt] |= byt as u64;
         self.length[0] += 8;
         if self.length[0] == 0 {
             self.length[1] += 1;

--- a/rust/hash512.rs
+++ b/rust/hash512.rs
@@ -117,34 +117,34 @@ pub struct HASH512 {
 
 impl HASH512 {
     fn s(n: u64, x: u64) -> u64 {
-        return ((x) >> n) | ((x) << (64 - n));
+        ((x) >> n) | ((x) << (64 - n))
     }
     fn r(n: u64, x: u64) -> u64 {
-        return (x) >> n;
+        (x) >> n
     }
 
     fn ch(x: u64, y: u64, z: u64) -> u64 {
-        return (x & y) ^ (!(x) & z);
+        (x & y) ^ (!(x) & z)
     }
 
     fn maj(x: u64, y: u64, z: u64) -> u64 {
-        return (x & y) ^ (x & z) ^ (y & z);
+        (x & y) ^ (x & z) ^ (y & z)
     }
 
     fn sig0(x: u64) -> u64 {
-        return HASH512::s(28, x) ^ HASH512::s(34, x) ^ HASH512::s(39, x);
+        HASH512::s(28, x) ^ HASH512::s(34, x) ^ HASH512::s(39, x)
     }
 
     fn sig1(x: u64) -> u64 {
-        return HASH512::s(14, x) ^ HASH512::s(18, x) ^ HASH512::s(41, x);
+        HASH512::s(14, x) ^ HASH512::s(18, x) ^ HASH512::s(41, x)
     }
 
     fn theta0(x: u64) -> u64 {
-        return HASH512::s(1, x) ^ HASH512::s(8, x) ^ HASH512::r(7, x);
+        HASH512::s(1, x) ^ HASH512::s(8, x) ^ HASH512::r(7, x)
     }
 
     fn theta1(x: u64) -> u64 {
-        return HASH512::s(19, x) ^ HASH512::s(61, x) ^ HASH512::r(6, x);
+        HASH512::s(19, x) ^ HASH512::s(61, x) ^ HASH512::r(6, x)
     }
 
     fn transform(&mut self) {
@@ -215,7 +215,7 @@ impl HASH512 {
             w: [0; 80],
         };
         nh.init();
-        return nh;
+        nh
     }
 
     pub fn new_copy(hh: &HASH512) -> HASH512 {
@@ -232,7 +232,7 @@ impl HASH512 {
         for i in 0..8 {
             nh.h[i] = hh.h[i];
         }
-        return nh;        
+        nh        
     }
 
     /* process a single byte */
@@ -285,11 +285,11 @@ impl HASH512 {
             digest[i] = ((self.h[i / 8] >> (8 * (7 - i % 8))) & 0xff) as u8;
         }
         self.init();
-        return digest;
+        digest
     }
     pub fn continuing_hash(&self) -> [u8; 64] {
         let mut sh=HASH512::new_copy(self);
-        return sh.hash();
+        sh.hash()
     }
 }
 

--- a/rust/hmac.rs
+++ b/rust/hmac.rs
@@ -34,6 +34,7 @@ pub const SHA512: usize = 64;
 
 /* General Purpose Hash function */
 
+#[allow(clippy::too_many_arguments)]
 pub fn GPhashit(hash: usize, sha: usize,w: &mut [u8],pad: usize,zpad: usize,a: Option<&[u8]>, n: isize, b: Option<&[u8]>) {
     let mut r: [u8; 64] = [0; 64];
 
@@ -117,18 +118,16 @@ pub fn GPhashit(hash: usize, sha: usize,w: &mut [u8],pad: usize,zpad: usize,a: O
         for i in 0..sha {
             w[i] = r[i]
         }
+    } else if pad <= sha {
+        for i in 0..pad {
+            w[i] = r[i]
+        }
     } else {
-        if pad <= sha {
-            for i in 0..pad {
-                w[i] = r[i]
-            }
-        } else {
-            for i in 0..sha {
-                w[i + pad - sha] = r[i]
-            }
-            for i in 0..(pad - sha) {
-                w[i] = 0
-            }
+        for i in 0..sha {
+            w[i + pad - sha] = r[i]
+        }
+        for i in 0..(pad - sha) {
+            w[i] = 0
         }
     }
 }
@@ -206,7 +205,7 @@ pub fn pbkdf2(hash: usize, sha: usize, pass: &[u8], salt: &[u8], rep: usize, ole
             u[j] = f[j]
         }
         for _ in 1..rep {
-            hmac1(hash, sha, &mut ku, sha, pass, &mut u);
+            hmac1(hash, sha, &mut ku, sha, pass, &u);
             for k in 0..sha {
                 u[k] = ku[k];
                 f[k] ^= u[k]
@@ -267,12 +266,12 @@ pub fn hmac1(hash: usize, sha: usize, tag: &mut [u8], olen: usize, k: &[u8], m: 
     for i in 0..lb {
         k0[i] ^= 0x36
     }
-    GPhashit(hash, sha, &mut b,0,0,Some(&mut k0[0..lb]), -1, Some(m));
+    GPhashit(hash, sha, &mut b,0,0,Some(&k0[0..lb]), -1, Some(m));
 
     for i in 0..lb {
         k0[i] ^= 0x6a
     }
-    GPhashit(hash, sha, tag,olen,0,Some(&mut k0[0..lb]), -1, Some(&b[0..sha]));
+    GPhashit(hash, sha, tag,olen,0,Some(&k0[0..lb]), -1, Some(&b[0..sha]));
 
     true
 }
@@ -297,24 +296,24 @@ pub fn hkdf_expand(hash: usize, hlen: usize, okm: &mut [u8], olen: usize, prk: &
     let mut m=0;
     for i in 1..=n {
         for j in 0..info.len() {
-            t[l]=info[j]; l=l+1;
+            t[l]=info[j]; l+=1;
         }
-        t[l]=i as u8; l=l+1;
+        t[l]=i as u8; l+=1;
         hmac1(hash,hlen,&mut k,hlen,prk,&t[0..l]);
         l=0;
         for j in 0..hlen {
-            okm[m]=k[j]; m=m+1;
-            t[l]=k[j]; l=l+1;
+            okm[m]=k[j]; m+=1;
+            t[l]=k[j]; l+=1;
         }
     }
     if flen>0 {
         for j in 0..info.len() {
-            t[l]=info[j]; l=l+1;
+            t[l]=info[j]; l+=1;
         }
-        t[l]=(n+1) as u8; l=l+1;
+        t[l]=(n+1) as u8; l+=1;
         hmac1(hash,hlen,&mut k,flen,prk,&t[0..l]);
         for j in 0..flen {
-            okm[m]=k[j]; m=m+1;
+            okm[m]=k[j]; m+=1;
         }
     }
 }

--- a/rust/hmac.rs
+++ b/rust/hmac.rs
@@ -232,7 +232,7 @@ fn blksize(hash: usize, sha: usize) -> usize {
     if hash == MC_SHA3 {
         lb=200-2*sha;
     }
-    return lb;
+    lb
 }
 
 /* Calculate HMAC of m using key k. HMAC is tag of length olen (which is length of tag) */
@@ -274,7 +274,7 @@ pub fn hmac1(hash: usize, sha: usize, tag: &mut [u8], olen: usize, k: &[u8], m: 
     }
     GPhashit(hash, sha, tag,olen,0,Some(&mut k0[0..lb]), -1, Some(&b[0..sha]));
 
-    return true;
+    true
 }
 
 pub fn hkdf_extract(hash: usize, hlen: usize, prk: &mut [u8],salt: Option<&[u8]>,ikm: &[u8]) {
@@ -320,7 +320,7 @@ pub fn hkdf_expand(hash: usize, hlen: usize, okm: &mut [u8], olen: usize, prk: &
 }
 
 fn ceil(a: usize,b: usize) -> usize {
-    return (a-1)/b+1;
+    (a-1)/b+1
 }
 
 pub fn xof_expand(hlen: usize,okm: &mut [u8],olen: usize,dst: &[u8],msg: &[u8]) {
@@ -507,7 +507,7 @@ pub fn pkcs15(sha: usize, m: &[u8], w: &mut [u8],rfs: usize) -> bool {
         i += 1
     }
 
-    return true;
+    true
 }
 /*
 pub fn printbinary(array: &[u8]) {
@@ -560,7 +560,7 @@ pub fn pss_encode(sha: usize, m: &[u8], rng: &mut RAND, f: &mut [u8], rfs: usize
         f[emlen+i-hlen-1]=h[i];
     }
     f[emlen-1]=0xbc as u8;
-    return true;
+    true
 }
 
 pub fn pss_verify(sha: usize, m: &[u8],f: &[u8]) -> bool {
@@ -623,7 +623,7 @@ pub fn pss_verify(sha: usize, m: &[u8],f: &[u8]) -> bool {
     if k!=0 {
         return false;
     }
-    return true;
+    true
 }
 /* OAEP Message Encoding for Encryption */
 pub fn oaep_encode(sha: usize, m: &[u8], rng: &mut RAND, p: Option<&[u8]>, f: &mut [u8], rfs: usize) -> bool {
@@ -681,7 +681,7 @@ pub fn oaep_encode(sha: usize, m: &[u8], rng: &mut RAND, p: Option<&[u8]>, f: &m
     for i in (0..d).rev() {
         f[i] = 0;
     }
-    return true;
+    true
 }
 
 /* OAEP Message Decoding for Decryption */
@@ -768,7 +768,7 @@ pub fn oaep_decode(sha: usize, p: Option<&[u8]>, f: &mut [u8],rfs :usize) -> usi
         dbmask[i] = 0
     }
 
-    return olen - seedlen - hlen - k - 1;
+    olen - seedlen - hlen - k - 1
 }
 
 /*

--- a/rust/hpke.rs
+++ b/rust/hpke.rs
@@ -177,10 +177,7 @@ pub fn deriveKeyPair(config_id: usize,mut sk: &mut [u8],mut pk: &mut [u8],seed: 
     if kem==32 || kem==33 {
         reverse(&mut pk);
     }
-    if counter<256 {
-        return true;
-    }
-    return false;
+    counter<256
 }
 
 #[allow(non_snake_case)]

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -16,6 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#![allow(clippy::many_single_char_names)]
 pub mod arch;
 pub mod aes;
 pub mod gcm;

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -17,6 +17,9 @@
  * limitations under the License.
  */
 #![allow(clippy::many_single_char_names)]
+#![allow(clippy::needless_range_loop)]
+#![allow(clippy::manual_memcpy)]
+#![allow(clippy::new_without_default)]
 pub mod arch;
 pub mod aes;
 pub mod gcm;

--- a/rust/mpin.rs
+++ b/rust/mpin.rs
@@ -51,7 +51,7 @@ pub const MAXPIN: i32 = 10000; /* PIN less than this */
 pub const PBLEN: i32 = 14; /* Number of bits in PIN */
 
 fn ceil(a: usize,b: usize) -> usize {
-    return (a-1)/b+1;
+    (a-1)/b+1
 }
 
 #[allow(non_snake_case)]
@@ -80,7 +80,7 @@ pub fn random_generate(mut rng: &mut RAND, s: &mut [u8]) -> isize {
     let r = BIG::new_ints(&rom::CURVE_ORDER);
     let sc = BIG::randtrunc(&r, 16 * ecp::AESKEY, &mut rng);
     sc.tobytes(s);
-    return 0;
+    0
 }
 
 /* Extract PIN from TOKEN for identity CID */
@@ -98,7 +98,7 @@ pub fn extract_pin(cid: &[u8], pin: i32, token: &mut [u8]) -> isize {
     R = R.pinmul(pin%MAXPIN, PBLEN);
     P.sub(&R);
     P.tobytes(token, false);
-    return 0;
+    0
 }
 
 /* Implement step 2 on client side of MPin protocol */
@@ -118,7 +118,7 @@ pub fn client_2(x: &[u8], y: &[u8], sec: &mut [u8]) -> isize {
     P = pair::g1mul(&P, &px);
     P.neg();
     P.tobytes(sec, false);
-    return 0;
+    0
 }
 
 /* Client secret CST=S*H(CID) where CID is client ID and S is master secret */
@@ -130,7 +130,7 @@ pub fn get_client_secret(s: &mut [u8], idhtc: &[u8], cst: &mut [u8]) -> isize {
         return INVALID_POINT;
     }
     pair::g1mul(&P, &sx).tobytes(cst, false);
-    return 0;
+    0
 }
 
 /* Implement step 1 on client side of MPin protocol */
@@ -170,7 +170,7 @@ pub fn client_1(
     P.tobytes(xid, false);
 
     T.tobytes(sec, false);
-    return 0;
+    0
 }
 
 
@@ -181,7 +181,7 @@ pub fn get_server_secret(s: &[u8], sst: &mut [u8]) -> isize {
     let sc = BIG::frombytes(s);
     Q = pair::g2mul(&Q, &sc);
     Q.tobytes(sst,false);
-    return 0;
+    0
 }
 
 /* Implement step 2 of MPin protocol on server side */
@@ -223,6 +223,6 @@ pub fn server(
     if !g.isunity() {
         return BAD_PIN;
     }
-    return 0;
+    0
 }
 

--- a/rust/mpin192.rs
+++ b/rust/mpin192.rs
@@ -51,7 +51,7 @@ pub const MAXPIN: i32 = 10000; /* PIN less than this */
 pub const PBLEN: i32 = 14; /* Number of bits in PIN */
 
 fn ceil(a: usize,b: usize) -> usize {
-    return (a-1)/b+1;
+    (a-1)/b+1
 }
 
 #[allow(non_snake_case)]
@@ -80,7 +80,7 @@ pub fn random_generate(mut rng: &mut RAND, s: &mut [u8]) -> isize {
     let r = BIG::new_ints(&rom::CURVE_ORDER);
     let sc = BIG::randtrunc(&r, 16 * ecp::AESKEY, &mut rng);
     sc.tobytes(s);
-    return 0;
+    0
 }
 
 /* Extract PIN from TOKEN for identity CID */
@@ -98,7 +98,7 @@ pub fn extract_pin(cid: &[u8], pin: i32, token: &mut [u8]) -> isize {
     R = R.pinmul(pin%MAXPIN, PBLEN);
     P.sub(&mut R);
     P.tobytes(token, false);
-    return 0;
+    0
 }
 
 /* Implement step 2 on client side of MPin protocol */
@@ -118,7 +118,7 @@ pub fn client_2(x: &[u8], y: &[u8], sec: &mut [u8]) -> isize {
     P = pair4::g1mul(&P, &px);
     P.neg();
     P.tobytes(sec, false);
-    return 0;
+    0
 }
 
 /* Client secret CST=S*H(CID) where CID is client ID and S is master secret */
@@ -130,7 +130,7 @@ pub fn get_client_secret(s: &mut [u8], idhtc: &[u8], cst: &mut [u8]) -> isize {
         return INVALID_POINT;
     }
     pair4::g1mul(&P, &sx).tobytes(cst, false);
-    return 0;
+    0
 }
 
 /* Implement step 1 on client side of MPin protocol */
@@ -170,7 +170,7 @@ pub fn client_1(
     P.tobytes(xid, false);
 
     T.tobytes(sec, false);
-    return 0;
+    0
 }
 
 
@@ -181,7 +181,7 @@ pub fn get_server_secret(s: &[u8], sst: &mut [u8]) -> isize {
     let sc = BIG::frombytes(s);
     Q = pair4::g2mul(&Q, &sc);
     Q.tobytes(sst,false);
-    return 0;
+    0
 }
 
 /* Implement step 2 of MPin protocol on server side */
@@ -223,5 +223,5 @@ pub fn server(
     if !g.isunity() {
         return BAD_PIN;
     }
-    return 0;
+    0
 }

--- a/rust/mpin256.rs
+++ b/rust/mpin256.rs
@@ -51,7 +51,7 @@ pub const MAXPIN: i32 = 10000; /* PIN less than this */
 pub const PBLEN: i32 = 14; /* Number of bits in PIN */
 
 fn ceil(a: usize,b: usize) -> usize {
-    return (a-1)/b+1;
+    (a-1)/b+1
 }
 
 #[allow(non_snake_case)]
@@ -80,7 +80,7 @@ pub fn random_generate(mut rng: &mut RAND, s: &mut [u8]) -> isize {
     let r = BIG::new_ints(&rom::CURVE_ORDER);
     let sc = BIG::randtrunc(&r, 16 * ecp::AESKEY, &mut rng);
     sc.tobytes(s);
-    return 0;
+    0
 }
 
 /* Extract PIN from TOKEN for identity CID */
@@ -98,7 +98,7 @@ pub fn extract_pin(cid: &[u8], pin: i32, token: &mut [u8]) -> isize {
     R = R.pinmul(pin%MAXPIN, PBLEN);
     P.sub(&mut R);
     P.tobytes(token, false);
-    return 0;
+    0
 }
 
 /* Implement step 2 on client side of MPin protocol */
@@ -118,7 +118,7 @@ pub fn client_2(x: &[u8], y: &[u8], sec: &mut [u8]) -> isize {
     P = pair8::g1mul(&P, &px);
     P.neg();
     P.tobytes(sec, false);
-    return 0;
+    0
 }
 
 /* Client secret CST=S*H(CID) where CID is client ID and S is master secret */
@@ -130,7 +130,7 @@ pub fn get_client_secret(s: &mut [u8], idhtc: &[u8], cst: &mut [u8]) -> isize {
         return INVALID_POINT;
     }
     pair8::g1mul(&P, &sx).tobytes(cst, false);
-    return 0;
+    0
 }
 
 /* Implement step 1 on client side of MPin protocol */
@@ -170,7 +170,7 @@ pub fn client_1(
     P.tobytes(xid, false);
 
     T.tobytes(sec, false);
-    return 0;
+    0
 }
 
 
@@ -181,7 +181,7 @@ pub fn get_server_secret(s: &[u8], sst: &mut [u8]) -> isize {
     let sc = BIG::frombytes(s);
     Q = pair8::g2mul(&Q, &sc);
     Q.tobytes(sst,false);
-    return 0;
+    0
 }
 
 /* Implement step 2 of MPin protocol on server side */
@@ -223,5 +223,5 @@ pub fn server(
     if !g.isunity() {
         return BAD_PIN;
     }
-    return 0;
+    0
 }

--- a/rust/nhs.rs
+++ b/rust/nhs.rs
@@ -399,13 +399,13 @@ fn nhs_unpack(array: &[u8], poly: &mut [i32]) {
     let mut j = 0;
     let mut i = 0;
     while i < DEGREE {
-        let a = ((array[j]) & 0xff) as i32;
-        let b = ((array[j + 1]) & 0xff) as i32;
-        let c = ((array[j + 2]) & 0xff) as i32;
-        let d = ((array[j + 3]) & 0xff) as i32;
-        let e = ((array[j + 4]) & 0xff) as i32;
-        let f = ((array[j + 5]) & 0xff) as i32;
-        let g = ((array[j + 6]) & 0xff) as i32;
+        let a = array[j] as i32;
+        let b = array[j + 1] as i32;
+        let c = array[j + 2] as i32;
+        let d = array[j + 3] as i32;
+        let e = array[j + 4] as i32;
+        let f = array[j + 5] as i32;
+        let g = array[j + 6] as i32;
         j += 7;
         poly[i] = a | ((b & 0x3f) << 8);
         poly[i + 1] = (b >> 6) | (c << 2) | ((d & 0xf) << 10);
@@ -488,7 +488,7 @@ fn poly_mul(p1: &mut [i32], p3: &[i32]) {
 
 fn poly_add(p1: &mut [i32], p3: &[i32]) {
     for i in 0..DEGREE {
-        p1[i] = p1[i] + p3[i];
+        p1[i] += p3[i];
     }
 }
 
@@ -510,7 +510,7 @@ fn poly_soft_reduce(poly: &mut [i32]) {
 fn poly_hard_reduce(poly: &mut [i32]) {
     for i in 0..DEGREE {
         let mut e = modmul(poly[i], ONE);
-        e = e - PRIME;
+        e -= PRIME;
         poly[i] = e + ((e >> (WL - 1)) & PRIME);
     }
 }

--- a/rust/nhs.rs
+++ b/rust/nhs.rs
@@ -212,28 +212,28 @@ const IROOTS: [i32; 1024] = [
 ];
 
 fn round(a: i32, b: i32) -> i32 {
-    return (a + b / 2) / b;
+    (a + b / 2) / b
 }
 
 /* Constant time absolute value */
 fn nabs(x: i32) -> i32 {
     let mask = x >> 31;
-    return (x + mask) ^ mask;
+    (x + mask) ^ mask
 }
 
 /* Montgomery stuff */
 
 fn redc(t: u64) -> i32 {
     let m = (t as u32).wrapping_mul(ND);
-    return (((m as u64) * (PRIME as u64) + t) >> WL) as i32;
+    (((m as u64) * (PRIME as u64) + t) >> WL) as i32
 }
 
 fn nres(x: i32) -> i32 {
-    return redc((x as u64) * R2MODP);
+    redc((x as u64) * R2MODP)
 }
 
 fn modmul(a: i32, b: i32) -> i32 {
-    return redc((a as u64) * (b as u64));
+    redc((a as u64) * (b as u64))
 }
 
 /* Cooley-Tukey NTT */

--- a/rust/pair.rs
+++ b/rust/pair.rs
@@ -240,11 +240,9 @@ pub fn precomp(T: &mut [FP4],GV: &ECP2) {
 
     let mut P=ECP2::new(); P.copy(GV);
 
-    if ecp::CURVE_PAIRING_TYPE==ecp::BN {
-        if ecp::SEXTIC_TWIST==ecp::M_TYPE {
-            f.inverse(None);
-            f.norm();
-        }
+    if (ecp::CURVE_PAIRING_TYPE==ecp::BN) && (ecp::SEXTIC_TWIST==ecp::M_TYPE) {
+        f.inverse(None);
+        f.norm();
     }
 
     let mut A = ECP2::new();
@@ -344,11 +342,9 @@ pub fn another(r:&mut [FP12],P1: &ECP2,Q1: &ECP) {
     Q.copy(Q1);
     Q.affine();
 
-    if ecp::CURVE_PAIRING_TYPE==ecp::BN {
-        if ecp::SEXTIC_TWIST==ecp::M_TYPE {
-            f.inverse(None);
-            f.norm();
-        }
+    if (ecp::CURVE_PAIRING_TYPE==ecp::BN) && (ecp::SEXTIC_TWIST==ecp::M_TYPE) {
+        f.inverse(None);
+        f.norm();
     }
 
     let qx = FP::new_copy(&Q.getpx());
@@ -405,11 +401,9 @@ pub fn ate(P1: &ECP2, Q1: &ECP) -> FP12 {
         return FP12::new_int(1);
     }
 
-    if ecp::CURVE_PAIRING_TYPE == ecp::BN {
-        if ecp::SEXTIC_TWIST == ecp::M_TYPE {
-            f.inverse(None);
-            f.norm();
-        }
+    if (ecp::CURVE_PAIRING_TYPE == ecp::BN) && (ecp::SEXTIC_TWIST == ecp::M_TYPE) {
+        f.inverse(None);
+        f.norm();
     } 
     let mut P = ECP2::new();
     P.copy(P1);
@@ -486,11 +480,9 @@ pub fn ate2(P1: &ECP2, Q1: &ECP, R1: &ECP2, S1: &ECP) -> FP12 {
         return ate(P1,Q1);
     }
 
-    if ecp::CURVE_PAIRING_TYPE == ecp::BN {
-        if ecp::SEXTIC_TWIST == ecp::M_TYPE {
-            f.inverse(None);
-            f.norm();
-        }
+    if (ecp::CURVE_PAIRING_TYPE == ecp::BN) && (ecp::SEXTIC_TWIST == ecp::M_TYPE) {
+        f.inverse(None);
+        f.norm();
     } 
 
     let mut P = ECP2::new();

--- a/rust/pair.rs
+++ b/rust/pair.rs
@@ -125,7 +125,7 @@ fn linedbl(A: &mut ECP2, qx: &FP, qy: &FP) -> FP12 {
     }
     let mut res= FP12::new_fp4s(&a, &b, &c);
     res.settype(fp12::SPARSER);
-    return res;
+    res
 }
 
 #[allow(non_snake_case)]
@@ -152,7 +152,7 @@ fn lineadd(A: &mut ECP2, B: &ECP2, qx: &FP, qy: &FP) -> FP12 {
     }
     let mut res= FP12::new_fp4s(&a, &b, &c);
     res.settype(fp12::SPARSER);
-    return res;
+    res
 }
 
 /* prepare ate parameter, n=6u+2 (BN) or n=u (BLS), n3=3*n */
@@ -171,13 +171,12 @@ fn lbits(n3: &mut BIG,n: &mut BIG) -> usize {
     n3.copy(&n);
     n3.pmul(3);
     n3.norm();
-    return n3.nbits();
+    n3.nbits()
 }
 
 /* prepare for multi-pairing */
 pub fn initmp() -> [FP12; ecp::ATE_BITS] {
-    let r: [FP12; ecp::ATE_BITS] = [FP12::new_int(1); ecp::ATE_BITS];
-    return r
+    [FP12::new_int(1); ecp::ATE_BITS]
 }
 
 /* basic Miller loop */
@@ -194,7 +193,7 @@ pub fn miller(r:&mut [FP12]) -> FP12 {
     }
     res.ssmul(&r[0]);
     r[0].zero();
-    return res;
+    res
 }
 
 fn pack(aa: &FP2,bb: &FP2,cc: &FP2) -> FP4 {
@@ -204,7 +203,7 @@ fn pack(aa: &FP2,bb: &FP2,cc: &FP2) -> FP4 {
     let mut b=FP2::new_copy(bb);
     a.mul(&i);
     b.mul(&i);
-    return FP4::new_fp2s(&a,&b);
+    FP4::new_fp2s(&a,&b)
 }
 
 fn unpack(t: &FP4, qx: &FP, qy: &FP) -> FP12 {
@@ -226,7 +225,7 @@ fn unpack(t: &FP4, qx: &FP, qy: &FP) -> FP12 {
     }
     let mut v=FP12::new_fp4s(&a,&b,&c);
     v.settype(fp12::SPARSEST);
-    return v;
+    v
 }
 
 #[allow(non_snake_case)]
@@ -469,7 +468,7 @@ pub fn ate(P1: &ECP2, Q1: &ECP) -> FP12 {
         r.ssmul(&lv);
     }
 
-    return r;
+    r
 }
 
 #[allow(non_snake_case)]
@@ -582,7 +581,7 @@ pub fn ate2(P1: &ECP2, Q1: &ECP, R1: &ECP2, S1: &ECP) -> FP12 {
 
     }
 
-    return r;
+    r
 }
 
 /* final exponentiation - keep separate for multi-pairings and to avoid thrashing stack */
@@ -760,7 +759,7 @@ pub fn fexp(m: &FP12) -> FP12 {
         r.copy(&y1);
         r.reduce(); */
     }
-    return r;
+    r
 }
 
 #[allow(non_snake_case)]
@@ -799,7 +798,7 @@ PFBNF */
         u[1].div(&x2);
         u[1].rsub(&q);
     }
-    return u;
+    u
 }
 
 #[allow(non_snake_case)]
@@ -846,7 +845,7 @@ PFBNF */
             u[3].copy(&t);
         }
     }
-    return u;
+    u
 }
 
 #[allow(non_snake_case)]
@@ -884,7 +883,7 @@ pub fn g1mul(P: &ECP, e: &BIG) -> ECP {
     } else {
         R = P.mul(e);
     }
-    return R;
+    R
 }
 
 #[allow(non_snake_case)]
@@ -925,7 +924,7 @@ pub fn g2mul(P: &ECP2, e: &BIG) -> ECP2 {
     } else {
         R.copy(&P.mul(e));
     }
-    return R;
+    R
 }
 
 /* f=f^e */
@@ -960,7 +959,7 @@ pub fn gtpow(d: &FP12, e: &BIG) -> FP12 {
     } else {
         r.copy(&d.pow(e));
     }
-    return r;
+    r
 }
 
 /* test G1 group membership */
@@ -974,7 +973,7 @@ pub fn g1member(P: &ECP) -> bool {
     if !W.is_infinity() {
         return false;
     }
-    return true;
+    true
 }
 
 /* test G2 group membership */
@@ -988,7 +987,7 @@ pub fn g2member(P: &ECP2) -> bool {
     if !W.is_infinity() {
         return false;
     }
-    return true;
+    true
 }
 
 /* test GT group membership */
@@ -1016,5 +1015,5 @@ pub fn gtmember(m: &FP12) -> bool {
     if !r.isunity() {
         return false;
     }
-    return true;
+    true
 }

--- a/rust/pair4.rs
+++ b/rust/pair4.rs
@@ -120,7 +120,7 @@ fn linedbl(A: &mut ECP4, qx: &FP, qy: &FP) -> FP24 {
     }
     let mut res= FP24::new_fp8s(&a, &b, &c);
     res.settype(fp24::SPARSER);
-    return res;
+    res
 }
 
 #[allow(non_snake_case)]
@@ -148,7 +148,7 @@ fn lineadd(A: &mut ECP4, B: &ECP4, qx: &FP, qy: &FP) -> FP24 {
 
     let mut res= FP24::new_fp8s(&a, &b, &c);
     res.settype(fp24::SPARSER);
-    return res;
+    res
 }
 
 /* prepare ate parameter, n=6u+2 (BN) or n=u (BLS), n3=3*n */
@@ -158,13 +158,12 @@ fn lbits(n3: &mut BIG,n: &mut BIG) -> usize {
     n3.copy(&n);
     n3.pmul(3);
     n3.norm();
-    return n3.nbits();
+    n3.nbits()
 }
 
 /* prepare for multi-pairing */
 pub fn initmp() -> [FP24; ecp::ATE_BITS] {
-    let r: [FP24; ecp::ATE_BITS] = [FP24::new_int(1); ecp::ATE_BITS];
-    return r
+    [FP24::new_int(1); ecp::ATE_BITS]
 }
 
 /* basic Miller loop */
@@ -181,7 +180,7 @@ pub fn miller(r:&mut [FP24]) -> FP24 {
     }
     res.ssmul(&r[0]);
     r[0].zero();
-    return res;
+    res
 }
 
 fn pack(aa: &FP4,bb: &FP4,cc: &FP4) -> FP8 {
@@ -191,7 +190,7 @@ fn pack(aa: &FP4,bb: &FP4,cc: &FP4) -> FP8 {
     let mut b=FP4::new_copy(bb);
     a.mul(&i);
     b.mul(&i);
-    return FP8::new_fp4s(&a,&b);
+    FP8::new_fp4s(&a,&b)
 }
 
 fn unpack(t: &FP8, qx: &FP, qy: &FP) -> FP24 {
@@ -213,7 +212,7 @@ fn unpack(t: &FP8, qx: &FP, qy: &FP) -> FP24 {
     }
     let mut v=FP24::new_fp8s(&a,&b,&c);
     v.settype(fp24::SPARSEST);
-    return v;
+    v
 }
 
 #[allow(non_snake_case)]
@@ -380,7 +379,7 @@ pub fn ate(P1: &ECP4, Q1: &ECP) -> FP24 {
         r.conj();
     }
 
-    return r;
+    r
 }
 
 #[allow(non_snake_case)]
@@ -456,7 +455,7 @@ pub fn ate2(P1: &ECP4, Q1: &ECP, R1: &ECP4, S1: &ECP) -> FP24 {
         r.conj();
     }
 
-    return r;
+    r
 }
 
 /* final exponentiation - keep separate for multi-pairings and to avoid thrashing stack */
@@ -607,7 +606,7 @@ pub fn fexp(m: &FP24) -> FP24 {
     r.mul(&t3);
 
     r.reduce(); */
-    return r;
+    r
 }
 
 #[allow(non_snake_case)]
@@ -624,7 +623,7 @@ fn glv(e: &BIG) -> [BIG; 2] {
     u[1].div(&x);
     u[1].rsub(&q);
 
-    return u;
+    u
 }
 
 #[allow(non_snake_case)]
@@ -660,7 +659,7 @@ pub fn gs(e: &BIG) -> [BIG; 8] {
         t.copy(&BIG::modneg(&mut u[7], &q));
         u[7].copy(&t);
     }
-    return u;
+    u
 }
 
 #[allow(non_snake_case)]
@@ -698,7 +697,7 @@ pub fn g1mul(P: &ECP, e: &BIG) -> ECP {
     } else {
         R = P.mul(e);
     }
-    return R;
+    R
 }
 
 #[allow(non_snake_case)]
@@ -744,7 +743,7 @@ pub fn g2mul(P: &ECP4, e: &BIG) -> ECP4 {
     } else {
         R.copy(&P.mul(e));
     }
-    return R;
+    R
 }
 
 /* f=f^e */
@@ -788,7 +787,7 @@ pub fn gtpow(d: &FP24, e: &BIG) -> FP24 {
     } else {
         r.copy(&d.pow(e));
     }
-    return r;
+    r
 }
 
 /* test G1 group membership */
@@ -802,7 +801,7 @@ pub fn g1member(P: &ECP) -> bool {
     if !W.is_infinity() {
         return false;
     }
-    return true;
+    true
 }
 
 /* test G2 group membership */
@@ -816,7 +815,7 @@ pub fn g2member(P: &ECP4) -> bool {
     if !W.is_infinity() {
         return false;
     }
-    return true;
+    true
 }
 
 /* test GT group membership */
@@ -844,6 +843,6 @@ pub fn gtmember(m: &FP24) -> bool {
     if !r.isunity() {
         return false;
     }
-    return true;
+    true
 }
 

--- a/rust/pair8.rs
+++ b/rust/pair8.rs
@@ -120,7 +120,7 @@ fn linedbl(A: &mut ECP8, qx: &FP, qy: &FP) -> FP48 {
   
     let mut res= FP48::new_fp16s(&a, &b, &c);
     res.settype(fp48::SPARSER);
-    return res;
+    res
 }
 
 #[allow(non_snake_case)]
@@ -148,7 +148,7 @@ fn lineadd(A: &mut ECP8, B: &ECP8, qx: &FP, qy: &FP) -> FP48 {
   
     let mut res= FP48::new_fp16s(&a, &b, &c);
     res.settype(fp48::SPARSER);
-    return res;
+    res
 }
 
 /* prepare ate parameter, n=6u+2 (BN) or n=u (BLS), n3=3*n */
@@ -158,7 +158,7 @@ fn lbits(n3: &mut BIG,n: &mut BIG) -> usize {
     n3.copy(&n);
     n3.pmul(3);
     n3.norm();
-    return n3.nbits();
+    n3.nbits()
 }
 
 /* prepare for multi-pairing */
@@ -181,7 +181,7 @@ pub fn miller(r:&mut [FP48]) -> FP48 {
     }
     res.ssmul(&r[0]);
     r[0].zero();
-    return res;
+    res
 }
 
 fn pack(aa: &FP8,bb: &FP8,cc: &FP8) -> FP16 {
@@ -191,7 +191,7 @@ fn pack(aa: &FP8,bb: &FP8,cc: &FP8) -> FP16 {
     let mut b=FP8::new_copy(bb);
     a.mul(&i);
     b.mul(&i);
-    return FP16::new_fp8s(&a,&b);
+    FP16::new_fp8s(&a,&b)
 }
 
 fn unpack(t: &FP16, qx: &FP, qy: &FP) -> FP48 {
@@ -213,7 +213,7 @@ fn unpack(t: &FP16, qx: &FP, qy: &FP) -> FP48 {
     }
     let mut v=FP48::new_fp16s(&a,&b,&c);
     v.settype(fp48::SPARSEST);
-    return v;
+    v
 }
 
 #[allow(non_snake_case)]
@@ -379,7 +379,7 @@ pub fn ate(P1: &ECP8, Q1: &ECP) -> FP48 {
         r.conj();
     }
 
-    return r;
+    r
 }
 
 #[allow(non_snake_case)]
@@ -455,7 +455,7 @@ pub fn ate2(P1: &ECP8, Q1: &ECP, R1: &ECP8, S1: &ECP) -> FP48 {
         r.conj();
     }
 
-    return r;
+    r
 }
 
 /* final exponentiation - keep separate for multi-pairings and to avoid thrashing stack */
@@ -712,7 +712,7 @@ pub fn fexp(m: &FP48) -> FP48 {
     r.mul(&t2);
 
     r.reduce(); */
-    return r;
+    r
 }
 
 #[allow(non_snake_case)]
@@ -730,7 +730,7 @@ fn glv(e: &BIG) -> [BIG; 2] {
     u[1].div(&x2);
     u[1].rsub(&q);
 
-    return u;
+    u
 }
 
 #[allow(non_snake_case)]
@@ -782,7 +782,7 @@ pub fn gs(e: &BIG) -> [BIG; 16] {
         t.copy(&BIG::modneg(&mut u[15], &q));
         u[15].copy(&t);
     }
-    return u;
+    u
 }
 
 #[allow(non_snake_case)]
@@ -820,7 +820,7 @@ pub fn g1mul(P: &ECP, e: &BIG) -> ECP {
     } else {
         R = P.mul(e);
     }
-    return R;
+    R
 }
 
 #[allow(non_snake_case)]
@@ -877,7 +877,7 @@ pub fn g2mul(P: &ECP8, e: &BIG) -> ECP8 {
     } else {
         R.copy(&P.mul(e));
     }
-    return R;
+    R
 }
 
 /* f=f^e */
@@ -929,7 +929,7 @@ pub fn gtpow(d: &FP48, e: &BIG) -> FP48 {
     } else {
         r.copy(&d.pow(e));
     }
-    return r;
+    r
 }
 
 /* test G1 group membership */
@@ -943,7 +943,7 @@ pub fn g1member(P: &ECP) -> bool {
     if !W.is_infinity() {
         return false;
     }
-    return true;
+    true
 }
 
 /* test G2 group membership */
@@ -957,7 +957,7 @@ pub fn g2member(P: &ECP8) -> bool {
     if !W.is_infinity() {
         return false;
     }
-    return true;
+    true
 }
 
 /* test GT group membership */
@@ -985,6 +985,6 @@ pub fn gtmember(m: &FP48) -> bool {
     if !r.isunity() {
         return false;
     }
-    return true;
+    true
 }
 

--- a/rust/rand.rs
+++ b/rust/rand.rs
@@ -80,7 +80,7 @@ impl RAND {
             self.ira[i] = pdiff;
             k += 1;
         }
-        return self.ira[0];
+        self.ira[0]
     }
 
     fn sirand(&mut self, seed: u32) {
@@ -158,7 +158,7 @@ impl RAND {
         if self.pool_ptr >= 32 {
             self.fill_pool()
         }
-        return (r & 0xff) as u8;
+        (r & 0xff) as u8
     }
 }
 

--- a/rust/rand.rs
+++ b/rust/rand.rs
@@ -116,10 +116,10 @@ impl RAND {
 
     fn pack(b: [u8; 4]) -> u32 {
         /* pack 4 bytes into a 32-bit Word */
-        return (((b[3] as u32) & 0xff) << 24)
+        (((b[3] as u32) & 0xff) << 24)
             | (((b[2] as u32) & 0xff) << 16)
             | (((b[1] as u32) & 0xff) << 8)
-            | ((b[0] as u32) & 0xff);
+            | ((b[0] as u32) & 0xff)
     }
 
     /* Initialize RNG with some real entropy from some external source */
@@ -158,7 +158,7 @@ impl RAND {
         if self.pool_ptr >= 32 {
             self.fill_pool()
         }
-        (r & 0xff) as u8
+        r
     }
 }
 

--- a/rust/sha3.rs
+++ b/rust/sha3.rs
@@ -62,7 +62,7 @@ pub struct SHA3 {
 
 impl SHA3 {
     fn rotl(x: u64, n: u64) -> u64 {
-        return ((x) << n) | ((x) >> (64 - n));
+        ((x) << n) | ((x) >> (64 - n))
     }
 
     fn transform(&mut self) {
@@ -151,7 +151,7 @@ impl SHA3 {
             s: [[0; 5]; 5],
         };
         nh.init(olen);
-        return nh;
+        nh
     }
 
     pub fn new_copy(hh: &SHA3) -> SHA3 {
@@ -169,7 +169,7 @@ impl SHA3 {
                 nh.s[i][j] = hh.s[i][j];
             }
         }
-        return nh;
+        nh
     }
 
     /* process a single byte */

--- a/rust/sha3.rs
+++ b/rust/sha3.rs
@@ -180,7 +180,7 @@ impl SHA3 {
         let ind = cnt / 8;
         let i = ind % 5;
         let j = ind / 5;
-        self.s[i][j] ^= ((byt & 0xff) as u64) << (8 * b);
+        self.s[i][j] ^= (byt as u64) << (8 * b);
         self.length += 1;
         if cnt + 1 == self.rate {
             self.transform();

--- a/rust/share.rs
+++ b/rust/share.rs
@@ -71,20 +71,20 @@ fn mul(x: u8, y: u8) -> u8 {
     let ly = (LTAB[iy] as usize) & 0xff;
 
     if x != 0 && y != 0 {
-        return PTAB[(lx + ly) % 255];
+        PTAB[(lx + ly) % 255]
     } else {
-        return 0;
+        0
     }
 }
 
 fn add(x: u8,y: u8) -> u8 {
-    return x^y;
+    x^y
 }
 
 fn inv(x: u8) -> u8 {
    let ix = (x as usize) & 0xff;
    let lx = (LTAB[ix] as usize) & 0xff; 
-   return PTAB[255-lx];
+   PTAB[255-lx]
 }
 
 /* Lagrange interpolation */
@@ -99,7 +99,7 @@ fn interpolate(n: usize, x: &[u8], y: &[u8]) -> u8 {
         }
         yp=add(yp,mul(p,y[i]));
     }
-    return yp;
+    yp
 }
 
 impl<'a> SHARE<'a> {
@@ -127,7 +127,7 @@ impl<'a> SHARE<'a> {
                 x=mul(x,ident as u8);
             }
         }        
-        return SHARE{id: ident as u8,nsr: numshare as u8,b:s};
+        SHARE{id: ident as u8,nsr: numshare as u8,b:s}
     } 
 /* recover M from shares */
     pub fn recover(m: &mut [u8],s: &[SHARE]) {

--- a/rust/share.rs
+++ b/rust/share.rs
@@ -151,7 +151,6 @@ impl<'a> SHARE<'a> {
             }
             m[j]=interpolate(nsr,&x,&y);
         }
-        return;    
     }
 }
 


### PR DESCRIPTION
# Motivation
Make the rust code a little more idiomatic.  In this PR I focused on purely mechanical changes.  The default rust linter now passes without complaint, although I have explicitly disabled some lints.

# Changes
* `return` is not usually needed as the last expression is returned.  This accounts for the vast majority of the changes. (about 600)
* There were instances of a`somevar & 0xff` where `somevar` is a u8.  Here I deleted the `& 0xff`.  (about 8 changes)
* One if/else chain in fp4.rs was nested with the else clauses ever deeper; I flattened this to a 1-deep if/else if/else if/else chain.
* I changed a few instances of `m = m + 1` to `m += 1`. (about 10 changes)

Not included:
* Linter errors about single letter variable names.  This is disabled for all the files in lib.rs.
* Linter errors about looping.  In Rust it is relatively rare to use loops and explicit indices; map, zip and for_each are typically used instead.  However such a conversion requires considerably more care and attention than removing surplus `mut` or `return` keywords so it seems wiser to keep these changes separate.

# Testing
I have run `python3 config64.py test` with a number of curves.