### PR TITLE
Rust: turning RAND into a trait, to enable custom RNGs.

### DIFF
--- a/rust/BenchtestALL.rs
+++ b/rust/BenchtestALL.rs
@@ -23,14 +23,14 @@ extern crate core;
 //use std::io;
 
 use core::arch;
-use core::rand::RAND;
+use core::rand::{RAND, RAND_impl};
 
 use std::time::Instant;
 
 const MIN_ITERS: isize = 10;
 const MIN_TIME: isize = 10;
 
-fn ed25519(mut rng: &mut RAND) {
+fn ed25519(rng: &mut impl RAND) {
     //use core::ed25519;
     use core::ed25519::big;
     use core::ed25519::ecp;
@@ -69,11 +69,11 @@ fn ed25519(mut rng: &mut RAND) {
     let G = ecp::ECP::generator();
 
     let r = big::BIG::new_ints(&rom::CURVE_ORDER);
-    
+
     let mut P = ecp::ECP::new();
-    let s = big::BIG::randomnum(&r, &mut rng);
+    let s = big::BIG::randomnum(&r, rng);
     for _ in 0..10 {
-        P.copy(&ecp::ECP::map2point(&fp::FP::new_rand(&mut rng)));
+        P.copy(&ecp::ECP::map2point(&fp::FP::new_rand(rng)));
         if P.is_infinity() {
             println!("HASH FAILURE - P=O");
             fail = true;
@@ -103,7 +103,7 @@ fn ed25519(mut rng: &mut RAND) {
     }
 }
 
-fn nist256(mut rng: &mut RAND) {
+fn nist256(rng: &mut impl RAND) {
     //use core::nist256;
     use core::nist256::big;
     use core::nist256::ecp;
@@ -143,15 +143,15 @@ fn nist256(mut rng: &mut RAND) {
     let r = big::BIG::new_ints(&rom::CURVE_ORDER);
 
     let mut P = ecp::ECP::new();
-    let s = big::BIG::randomnum(&r, &mut rng);
+    let s = big::BIG::randomnum(&r, rng);
     for _ in 0..10 {
-        P.copy(&ecp::ECP::map2point(&fp::FP::new_rand(&mut rng)));
+        P.copy(&ecp::ECP::map2point(&fp::FP::new_rand(rng)));
         if P.is_infinity() {
             println!("HASH FAILURE - P=O");
             fail = true;
         }
     }
-    
+
     P = G.mul(&r);
     if !P.is_infinity() {
         println!("FAILURE - rG!=O");
@@ -175,7 +175,7 @@ fn nist256(mut rng: &mut RAND) {
     }
 }
 
-fn goldilocks(mut rng: &mut RAND) {
+fn goldilocks(rng: &mut impl RAND) {
     //use core::goldilocks;
     use core::goldilocks::big;
     use core::goldilocks::ecp;
@@ -215,9 +215,9 @@ fn goldilocks(mut rng: &mut RAND) {
     let r = big::BIG::new_ints(&rom::CURVE_ORDER);
 
     let mut P = ecp::ECP::new();
-    let s = big::BIG::randomnum(&r, &mut rng);
+    let s = big::BIG::randomnum(&r, rng);
     for _ in 0..10 {
-        P.copy(&ecp::ECP::map2point(&fp::FP::new_rand(&mut rng)));
+        P.copy(&ecp::ECP::map2point(&fp::FP::new_rand(rng)));
         if P.is_infinity() {
             println!("HASH FAILURE - P=O");
             fail = true;
@@ -247,7 +247,7 @@ fn goldilocks(mut rng: &mut RAND) {
     }
 }
 
-fn bn254(mut rng: &mut RAND) {
+fn bn254(rng: &mut impl RAND) {
     //use core::bn254;
     use core::bn254::big;
     use core::bn254::ecp;
@@ -272,14 +272,14 @@ fn bn254(mut rng: &mut RAND) {
     let G = ecp::ECP::generator();
 
     let r = big::BIG::new_ints(&rom::CURVE_ORDER);
-    let s = big::BIG::randomnum(&r, &mut rng);
+    let s = big::BIG::randomnum(&r, rng);
 
-    let mut P = ecp::ECP::map2point(&fp::FP::new_rand(&mut rng));
+    let mut P = ecp::ECP::map2point(&fp::FP::new_rand(rng));
     if P.is_infinity() {
         println!("HASH FAILURE - P=O");
         fail = true;
-    } 
-    
+    }
+
     P = pair::g1mul(&G, &r);
 
     if !P.is_infinity() {
@@ -302,7 +302,7 @@ fn bn254(mut rng: &mut RAND) {
 
     let mut Q = ecp2::ECP2::generator();
 
-    let mut W = ecp2::ECP2::map2point(&fp2::FP2::new_rand(&mut rng));
+    let mut W = ecp2::ECP2::map2point(&fp2::FP2::new_rand(rng));
     W.cfp();
     if W.is_infinity() {
         println!("HASHING FAILURE - P=O");
@@ -443,7 +443,7 @@ fn bn254(mut rng: &mut RAND) {
     }
 }
 
-fn bls12383(mut rng: &mut RAND) {
+fn bls12383(rng: &mut impl RAND) {
     //use core::bls12383;
     use core::bls12383::big;
     use core::bls12383::ecp;
@@ -452,8 +452,6 @@ fn bls12383(mut rng: &mut RAND) {
     use core::bls12383::fp2;
     use core::bls12383::pair;
     use core::bls12383::rom;
-    use core::bls12383::ecp::ECP;
-    use core::bls12383::big::BIG;
 
     let mut fail = false;
     println!("\nTesting/Timing bls12383 Pairings");
@@ -470,7 +468,7 @@ fn bls12383(mut rng: &mut RAND) {
 
     let G = ecp::ECP::generator();
 /*
-    println!("g1= {} ",G.tostring()); 
+    println!("g1= {} ",G.tostring());
     let mut T: [ECP; 4] = [
         ECP::new(),
         ECP::new(),
@@ -486,18 +484,18 @@ fn bls12383(mut rng: &mut RAND) {
     T[0].copy(&G);
     e[0].one();
     let R=ECP::muln(1,&T,&e);
-    println!("g1= {} ",R.tostring()); 
+    println!("g1= {} ",R.tostring());
 */
 
     let r = big::BIG::new_ints(&rom::CURVE_ORDER);
-    let s = big::BIG::randomnum(&r, &mut rng);
+    let s = big::BIG::randomnum(&r, rng);
 
-    let mut P = ecp::ECP::map2point(&fp::FP::new_rand(&mut rng));
+    let mut P = ecp::ECP::map2point(&fp::FP::new_rand(rng));
     if P.is_infinity() {
         println!("HASH FAILURE - P=O");
         fail = true;
     }
-    
+
     P = pair::g1mul(&G, &r);
 
     if !P.is_infinity() {
@@ -520,7 +518,7 @@ fn bls12383(mut rng: &mut RAND) {
 
     let mut Q = ecp2::ECP2::generator();
 
-    let mut W = ecp2::ECP2::map2point(&fp2::FP2::new_rand(&mut rng));
+    let mut W = ecp2::ECP2::map2point(&fp2::FP2::new_rand(rng));
     W.cfp();
     if W.is_infinity() {
         println!("HASHING FAILURE - P=O");
@@ -660,7 +658,7 @@ fn bls12383(mut rng: &mut RAND) {
     }
 }
 
-fn bls24479(mut rng: &mut RAND) {
+fn bls24479(rng: &mut impl RAND) {
     //use core::bls24479;
     use core::bls24479::big;
     use core::bls24479::ecp;
@@ -685,14 +683,14 @@ fn bls24479(mut rng: &mut RAND) {
     let G = ecp::ECP::generator();
 
     let r = big::BIG::new_ints(&rom::CURVE_ORDER);
-    let s = big::BIG::randomnum(&r, &mut rng);
+    let s = big::BIG::randomnum(&r, rng);
 
-    let mut P = ecp::ECP::map2point(&fp::FP::new_rand(&mut rng));
+    let mut P = ecp::ECP::map2point(&fp::FP::new_rand(rng));
     if P.is_infinity() {
         println!("HASH FAILURE - P=O");
         fail = true;
     }
-    
+
     P = pair4::g1mul(&G, &r);
 
     if !P.is_infinity() {
@@ -715,7 +713,7 @@ fn bls24479(mut rng: &mut RAND) {
 
     let mut Q = ecp4::ECP4::generator();
 
-    let mut W = ecp4::ECP4::map2point(&fp4::FP4::new_rand(&mut rng));
+    let mut W = ecp4::ECP4::map2point(&fp4::FP4::new_rand(rng));
     W.cfp();
     if W.is_infinity() {
         println!("HASHING FAILURE - P=O");
@@ -842,7 +840,7 @@ fn bls24479(mut rng: &mut RAND) {
     }
 }
 
-fn bls48556(mut rng: &mut RAND) {
+fn bls48556(rng: &mut impl RAND) {
     //use core::bls48556;
     use core::bls48556::big;
     use core::bls48556::ecp;
@@ -867,14 +865,14 @@ fn bls48556(mut rng: &mut RAND) {
     let G = ecp::ECP::generator();
 
     let r = big::BIG::new_ints(&rom::CURVE_ORDER);
-    let s = big::BIG::randomnum(&r, &mut rng);
+    let s = big::BIG::randomnum(&r, rng);
 
-    let mut P = ecp::ECP::map2point(&fp::FP::new_rand(&mut rng));
+    let mut P = ecp::ECP::map2point(&fp::FP::new_rand(rng));
     if P.is_infinity() {
         println!("HASH FAILURE - P=O");
         fail = true;
     }
-    
+
     P = pair8::g1mul(&G, &r);
 
     if !P.is_infinity() {
@@ -897,7 +895,7 @@ fn bls48556(mut rng: &mut RAND) {
 
     let mut Q = ecp8::ECP8::generator();
 
-    let mut W = ecp8::ECP8::map2point(&fp8::FP8::new_rand(&mut rng));
+    let mut W = ecp8::ECP8::map2point(&fp8::FP8::new_rand(rng));
     W.cfp();
     if W.is_infinity() {
         println!("HASHING FAILURE - P=O");
@@ -1024,7 +1022,7 @@ fn bls48556(mut rng: &mut RAND) {
     }
 }
 
-fn rsa2048(mut rng: &mut RAND) {
+fn rsa2048(rng: &mut impl RAND) {
     use core::rsa2048::ff;
     use core::rsa2048::rsa;
     let mut pbc = rsa::new_public_key(ff::FFLEN);
@@ -1041,7 +1039,7 @@ fn rsa2048(mut rng: &mut RAND) {
     let mut iterations = 0;
     let mut dur = 0 as u64;
     while dur < (MIN_TIME as u64) * 1000 || iterations < MIN_ITERS {
-        rsa::key_pair(&mut rng, 65537, &mut prv, &mut pbc);
+        rsa::key_pair(rng, 65537, &mut prv, &mut pbc);
         iterations += 1;
         let elapsed = start.elapsed();
         dur = (elapsed.as_secs() * 1_000) + (elapsed.subsec_nanos() / 1_000_000) as u64;
@@ -1101,7 +1099,7 @@ fn rsa2048(mut rng: &mut RAND) {
 fn main() {
     let mut raw: [u8; 100] = [0; 100];
 
-    let mut rng = RAND::new();
+    let mut rng = RAND_impl::new();
     rng.clean();
     for i in 0..100 {
         raw[i] = i as u8

--- a/rust/TestBLS.rs
+++ b/rust/TestBLS.rs
@@ -32,7 +32,7 @@ Swap G1S and G2S in this program
 
 extern crate core;
 
-use core::rand::RAND;
+use core::rand::{RAND, RAND_impl};
 
 pub fn printbinary(array: &[u8]) {
     for i in 0..array.len() {
@@ -41,7 +41,7 @@ pub fn printbinary(array: &[u8]) {
     println!("")
 }
 
-fn bls_bn254(rng: &mut RAND) {
+fn bls_bn254(rng: &mut impl RAND) {
     use core::bn254::bls;
 
     const BFS: usize = bls::BFS;
@@ -92,7 +92,7 @@ fn bls_bn254(rng: &mut RAND) {
     }
 }
 
-fn bls_bls12383(rng: &mut RAND) {
+fn bls_bls12383(rng: &mut impl RAND) {
     use core::bls12383::bls;
 
     const BFS: usize = bls::BFS;
@@ -141,7 +141,7 @@ fn bls_bls12383(rng: &mut RAND) {
     }
 }
 
-fn bls_bls24479(rng: &mut RAND) {
+fn bls_bls24479(rng: &mut impl RAND) {
     use core::bls24479::bls192;
 
     const BFS: usize = bls192::BFS;
@@ -189,7 +189,7 @@ fn bls_bls24479(rng: &mut RAND) {
     }
 }
 
-fn bls_bls48556(rng: &mut RAND) {
+fn bls_bls48556(rng: &mut impl RAND) {
     use core::bls48556::bls256;
 
     const BFS: usize = bls256::BFS;
@@ -242,7 +242,7 @@ fn main() {
 
     let mut raw: [u8; 100] = [0; 100];
 
-    let mut rng = RAND::new();
+    let mut rng = RAND_impl::new();
     rng.clean();
     for i in 0..100 {
         raw[i] = i as u8

--- a/rust/TestECC.rs
+++ b/rust/TestECC.rs
@@ -23,7 +23,7 @@ extern crate core;
 
 use std::str;
 
-use core::rand::RAND;
+use core::rand::{RAND, RAND_impl};
 use core::hmac;
 
 pub fn printbinary(array: &[u8]) {
@@ -33,7 +33,7 @@ pub fn printbinary(array: &[u8]) {
     println!("")
 }
 
-fn ecdh_ed25519(mut rng: &mut RAND) {
+fn ecdh_ed25519(rng: &mut impl RAND) {
     //use core::ed25519;
     use core::ed25519::ecdh;
     use core::ed25519::ecp;
@@ -75,7 +75,7 @@ fn ecdh_ed25519(mut rng: &mut RAND) {
     printbinary(&s0);
 
     /* Generate Key pair S/W */
-    ecdh::key_pair_generate(None, &mut s0, &mut w0);
+    ecdh::key_pair_generate(None::<&mut RAND_impl>, &mut s0, &mut w0);
 
     print!("Alice's public key= 0x");
     printbinary(&w0);
@@ -87,7 +87,7 @@ fn ecdh_ed25519(mut rng: &mut RAND) {
     }
 
     /* Random private key for other party */
-    ecdh::key_pair_generate(Some(&mut rng), &mut s1, &mut w1);
+    ecdh::key_pair_generate(Some(rng), &mut s1, &mut w1);
 
     print!("Servers private key= 0x");
     printbinary(&s1);
@@ -139,7 +139,7 @@ fn ecdh_ed25519(mut rng: &mut RAND) {
         p2[2] = 0x2;
         p2[3] = 0x3;
 
-        let cc = ecdh::ecies_encrypt(sha, &p1, &p2, &mut rng, &w1, &m[0..17], &mut v, &mut t);
+        let cc = ecdh::ecies_encrypt(sha, &p1, &p2, rng, &w1, &m[0..17], &mut v, &mut t);
 
         if let Some(mut c) = cc {
             println!("Ciphertext= ");
@@ -166,7 +166,7 @@ fn ecdh_ed25519(mut rng: &mut RAND) {
 
         println!("Testing ECDSA");
 
-        if ecdh::ecpsp_dsa(sha, &mut rng, &s0, &m[0..17], &mut cs, &mut ds) != 0 {
+        if ecdh::ecpsp_dsa(sha, rng, &s0, &m[0..17], &mut cs, &mut ds) != 0 {
             println!("***ECDSA Signature Failed");
             return;
         }
@@ -185,7 +185,7 @@ fn ecdh_ed25519(mut rng: &mut RAND) {
     }
 }
 
-fn ecdh_nist256(mut rng: &mut RAND) {
+fn ecdh_nist256(rng: &mut impl RAND) {
     //use core::nist256;
     use core::nist256::ecdh;
     use core::nist256::ecp;
@@ -227,7 +227,7 @@ fn ecdh_nist256(mut rng: &mut RAND) {
     printbinary(&s0);
 
     /* Generate Key pair S/W */
-    ecdh::key_pair_generate(None, &mut s0, &mut w0);
+    ecdh::key_pair_generate(None::<&mut RAND_impl>, &mut s0, &mut w0);
 
     print!("Alice's public key= 0x");
     printbinary(&w0);
@@ -239,7 +239,7 @@ fn ecdh_nist256(mut rng: &mut RAND) {
     }
 
     /* Random private key for other party */
-    ecdh::key_pair_generate(Some(&mut rng), &mut s1, &mut w1);
+    ecdh::key_pair_generate(Some(rng), &mut s1, &mut w1);
 
     print!("Servers private key= 0x");
     printbinary(&s1);
@@ -291,7 +291,7 @@ fn ecdh_nist256(mut rng: &mut RAND) {
         p2[2] = 0x2;
         p2[3] = 0x3;
 
-        let cc = ecdh::ecies_encrypt(sha, &p1, &p2, &mut rng, &w1, &m[0..17], &mut v, &mut t);
+        let cc = ecdh::ecies_encrypt(sha, &p1, &p2, rng, &w1, &m[0..17], &mut v, &mut t);
 
         if let Some(mut c) = cc {
             println!("Ciphertext= ");
@@ -318,7 +318,7 @@ fn ecdh_nist256(mut rng: &mut RAND) {
 
         println!("Testing ECDSA");
 
-        if ecdh::ecpsp_dsa(sha, &mut rng, &s0, &m[0..17], &mut cs, &mut ds) != 0 {
+        if ecdh::ecpsp_dsa(sha, rng, &s0, &m[0..17], &mut cs, &mut ds) != 0 {
             println!("***ECDSA Signature Failed");
             return;
         }
@@ -337,12 +337,12 @@ fn ecdh_nist256(mut rng: &mut RAND) {
     }
 }
 
-fn ecdh_goldilocks(mut rng: &mut RAND) {
+fn ecdh_goldilocks(rng: &mut impl RAND) {
     //use core::goldilocks;
     use core::goldilocks::ecdh;
     use core::goldilocks::ecp;
 
-    
+
     let pw = "M0ng00se";
     let pp: &[u8] = b"M0ng00se";
     const EFS: usize = ecdh::EFS;
@@ -380,7 +380,7 @@ fn ecdh_goldilocks(mut rng: &mut RAND) {
     printbinary(&s0);
 
     /* Generate Key pair S/W */
-    ecdh::key_pair_generate(None, &mut s0, &mut w0);
+    ecdh::key_pair_generate(None::<&mut RAND_impl>, &mut s0, &mut w0);
 
     print!("Alice's public key= 0x");
     printbinary(&w0);
@@ -392,7 +392,7 @@ fn ecdh_goldilocks(mut rng: &mut RAND) {
     }
 
     /* Random private key for other party */
-    ecdh::key_pair_generate(Some(&mut rng), &mut s1, &mut w1);
+    ecdh::key_pair_generate(Some(rng), &mut s1, &mut w1);
 
     print!("Servers private key= 0x");
     printbinary(&s1);
@@ -444,7 +444,7 @@ fn ecdh_goldilocks(mut rng: &mut RAND) {
         p2[2] = 0x2;
         p2[3] = 0x3;
 
-        let cc = ecdh::ecies_encrypt(sha, &p1, &p2, &mut rng, &w1, &m[0..17], &mut v, &mut t);
+        let cc = ecdh::ecies_encrypt(sha, &p1, &p2, rng, &w1, &m[0..17], &mut v, &mut t);
 
         if let Some(mut c) = cc {
             println!("Ciphertext= ");
@@ -471,7 +471,7 @@ fn ecdh_goldilocks(mut rng: &mut RAND) {
 
         println!("Testing ECDSA");
 
-        if ecdh::ecpsp_dsa(sha, &mut rng, &s0, &m[0..17], &mut cs, &mut ds) != 0 {
+        if ecdh::ecpsp_dsa(sha, rng, &s0, &m[0..17], &mut cs, &mut ds) != 0 {
             println!("***ECDSA Signature Failed");
             return;
         }
@@ -490,7 +490,7 @@ fn ecdh_goldilocks(mut rng: &mut RAND) {
     }
 }
 
-fn rsa_2048(mut rng: &mut RAND) {
+fn rsa_2048(rng: &mut impl RAND) {
     //use core::rsa2048;
     use core::rsa2048::ff;
     use core::rsa2048::rsa;
@@ -510,10 +510,10 @@ fn rsa_2048(mut rng: &mut RAND) {
 
     println!("\nTesting RSA");
     println!("Generating public/private key pair");
-    rsa::key_pair(&mut rng, 65537, &mut prv, &mut pbc);
+    rsa::key_pair(rng, 65537, &mut prv, &mut pbc);
 
     println!("Encrypting test string\n");
-    hmac::oaep_encode(sha, &message, &mut rng, None, &mut e, RFS); /* OAEP encode message M to E  */
+    hmac::oaep_encode(sha, &message, rng, None, &mut e, RFS); /* OAEP encode message M to E  */
 
     rsa::encrypt(&pbc, &e, &mut c); /* encrypt encoded message */
     print!("Ciphertext= 0x");
@@ -527,7 +527,7 @@ fn rsa_2048(mut rng: &mut RAND) {
     print!("{}", &mess);
 
 //    print!("M= 0x"); printbinary(&message);
-    hmac::pss_encode(sha,&message,&mut rng,&mut c,RFS);
+    hmac::pss_encode(sha,&message,rng,&mut c,RFS);
 //    print!("T= 0x"); printbinary(&c);
     if hmac::pss_verify(sha,&message,&c) {
         println!("PSS Encoding OK");
@@ -567,7 +567,7 @@ fn rsa_2048(mut rng: &mut RAND) {
 fn main() {
     let mut raw: [u8; 100] = [0; 100];
 
-    let mut rng = RAND::new();
+    let mut rng = RAND_impl::new();
     rng.clean();
     for i in 0..100 {
         raw[i] = i as u8

--- a/rust/TestNHS.rs
+++ b/rust/TestNHS.rs
@@ -28,7 +28,7 @@ extern crate core;
 //use std::str;
 //use std::io;
 
-use core::rand::RAND;
+use core::rand::{RAND, RAND_impl};
 use core::nhs;
 
 fn main() {
@@ -36,7 +36,7 @@ fn main() {
 
     println!("\nTesting New Hope Key Exchange");
 
-    let mut srng = RAND::new();
+    let mut srng = RAND_impl::new();
     srng.clean();
     for i in 0..100 {
         raw[i] = (i + 1) as u8
@@ -44,7 +44,7 @@ fn main() {
 
     srng.seed(100, &raw);
 
-    let mut crng = RAND::new();
+    let mut crng = RAND_impl::new();
     crng.clean();
     for i in 0..100 {
         raw[i] = (i + 2) as u8

--- a/rust/big.rs
+++ b/rust/big.rs
@@ -51,7 +51,7 @@ impl std::fmt::Debug for BIG {
     fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(formatter, "{}", self.tostring())
     }
-}    
+}
 impl std::fmt::Display for BIG {
     fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(formatter, "{}", self.tostring())
@@ -653,7 +653,7 @@ impl BIG {
     }
 
     /* get 8*MODBYTES size random number */
-    pub fn random(rng: &mut RAND) -> BIG {
+    pub fn random(rng: &mut impl RAND) -> BIG {
         let mut m = BIG::new();
         let mut j = 0;
         let mut r: u8 = 0;
@@ -676,7 +676,7 @@ impl BIG {
     }
 
     /* Create random BIG in portable way, one bit at a time */
-    pub fn randomnum(q: &BIG, rng: &mut RAND) -> BIG {
+    pub fn randomnum(q: &BIG, rng: &mut impl RAND) -> BIG {
         let mut d = DBIG::new();
         let mut j = 0;
         let mut r: u8 = 0;
@@ -698,7 +698,7 @@ impl BIG {
     }
 
 /* create randum BIG less than r and less than trunc bits */
-    pub fn randtrunc(q: &BIG, trunc: usize, rng: &mut RAND) -> BIG {
+    pub fn randtrunc(q: &BIG, trunc: usize, rng: &mut impl RAND) -> BIG {
         let mut m=BIG::randomnum(q,rng);
 	    if q.nbits() > trunc {
 	        m.mod2m(trunc);

--- a/rust/ecdh.rs
+++ b/rust/ecdh.rs
@@ -54,15 +54,15 @@ pub fn in_range(s: &[u8]) -> bool {
  * If RNG is NULL then the private key is provided externally in s
  * otherwise it is generated randomly internally */
 #[allow(non_snake_case)]
-pub fn key_pair_generate(rng: Option<&mut RAND>, s: &mut [u8], w: &mut [u8]) -> isize {
+pub fn key_pair_generate(rng: Option<&mut impl RAND>, s: &mut [u8], w: &mut [u8]) -> isize {
     let res = 0;
     let mut sc: BIG;
     let G = ECP::generator();
 
     let r = BIG::new_ints(&rom::CURVE_ORDER);
 
-    if let Some(mut x) = rng {
-        sc = BIG::randtrunc(&r, 16 * ecp::AESKEY, &mut x);
+    if let Some(x) = rng {
+        sc = BIG::randtrunc(&r, 16 * ecp::AESKEY, x);
     } else {
         sc = BIG::frombytes(&s);
         sc.rmod(&r);
@@ -154,7 +154,7 @@ pub fn ecpsvdp_dh(s: &[u8], wd: &[u8], z: &mut [u8], typ: isize) -> isize {
 #[allow(non_snake_case)]
 pub fn ecpsp_dsa(
     sha: usize,
-    rng: &mut RAND,
+    rng: &mut impl RAND,
     s: &[u8],
     f: &[u8],
     c: &mut [u8],
@@ -274,7 +274,7 @@ pub fn ecies_encrypt(
     sha: usize,
     p1: &[u8],
     p2: &[u8],
-    rng: &mut RAND,
+    rng: &mut impl RAND,
     w: &[u8],
     m: &[u8],
     v: &mut [u8],

--- a/rust/ff.rs
+++ b/rust/ff.rs
@@ -47,7 +47,7 @@ impl std::fmt::Debug for FF {
     fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(formatter, "{}", self.tostring())
     }
-}    
+}
 impl std::fmt::Display for FF {
     fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(formatter, "{}", self.tostring())
@@ -723,7 +723,7 @@ impl FF {
         u
     }
 
-    pub fn random(&mut self, rng: &mut RAND) {
+    pub fn random(&mut self, rng: &mut impl RAND) {
         let n = self.length;
         for i in 0..n {
             self.v[i].copy(&BIG::random(rng))
@@ -735,7 +735,7 @@ impl FF {
     }
 
     /* generate random x less than p */
-    pub fn randomnum(&mut self, p: &FF, rng: &mut RAND) {
+    pub fn randomnum(&mut self, p: &FF, rng: &mut impl RAND) {
         let n = self.length;
         let mut d = FF::new_int(2 * n);
 
@@ -1002,7 +1002,7 @@ impl FF {
     }
 
     /* Miller-Rabin test for primality. Slow. */
-    pub fn prime(pp: &FF, rng: &mut RAND) -> bool {
+    pub fn prime(pp: &FF, rng: &mut impl RAND) -> bool {
         let mut s = 0;
         let n = pp.length;
         let mut d = FF::new_int(n);

--- a/rust/fp.rs
+++ b/rust/fp.rs
@@ -36,7 +36,7 @@ impl std::fmt::Debug for FP {
     fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(formatter, "{}", self.tostring())
     }
-}    
+}
 impl std::fmt::Display for FP {
     fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(formatter, "{}", self.tostring())
@@ -103,7 +103,7 @@ impl FP {
         f
     }
 
-    pub fn new_rand(rng: &mut RAND) -> FP {
+    pub fn new_rand(rng: &mut impl RAND) -> FP {
         let m = BIG::new_ints(&rom::MODULUS);
         let w = BIG::randomnum(&m,rng);
         FP::new_big(&w)
@@ -711,7 +711,7 @@ impl FP {
         m.shr(e);
         m.dec(1);
         m.fshr(1);
-        
+
         self.copy(&self.pow(&m));
     }
 
@@ -795,7 +795,7 @@ impl FP {
         let mut r=FP::new_copy(self);
         r.mul(&g);
         let mut b=FP::new_copy(&t);
-       
+
         for k in (2..=e).rev()   //(int k=e;k>1;k--)
         {
             for _ in 1..k-1 {

--- a/rust/fp2.rs
+++ b/rust/fp2.rs
@@ -36,7 +36,7 @@ impl std::fmt::Debug for FP2 {
     fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(formatter, "{}", self.tostring())
     }
-}    
+}
 impl std::fmt::Display for FP2 {
     fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(formatter, "{}", self.tostring())
@@ -100,7 +100,7 @@ impl FP2 {
         f
     }
 
-    pub fn new_rand(rng: &mut RAND) -> FP2 {
+    pub fn new_rand(rng: &mut impl RAND) -> FP2 {
         FP2::new_fps(&FP::new_rand(rng),&FP::new_rand(rng))
     }
 
@@ -142,7 +142,7 @@ impl FP2 {
         self.a.tobytes(&mut t);
         for i in 0..MB {
             bf[i+MB]=t[i];
-        }       
+        }
     }
 
     pub fn frombytes(bf: &[u8]) -> FP2 {
@@ -442,7 +442,7 @@ impl FP2 {
         let sgn=self.sign();
         let mut nr=FP2::new_copy(&self);
         nr.neg(); nr.norm();
-        self.cmove(&nr,sgn);   
+        self.cmove(&nr,sgn);
     }
 
     /* output to hex string */

--- a/rust/fp4.rs
+++ b/rust/fp4.rs
@@ -36,7 +36,7 @@ impl std::fmt::Debug for FP4 {
     fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(formatter, "{}", self.tostring())
     }
-}    
+}
 impl std::fmt::Display for FP4 {
     fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(formatter, "{}", self.tostring())
@@ -93,7 +93,7 @@ impl FP4 {
         f
     }
 
-    pub fn new_rand(rng: &mut RAND) -> FP4 {
+    pub fn new_rand(rng: &mut impl RAND) -> FP4 {
        FP4::new_fp2s(&FP2::new_rand(rng),&FP2::new_rand(rng))
     }
 
@@ -162,7 +162,7 @@ impl FP4 {
         self.a.tobytes(&mut t);
         for i in 0..MB {
             bf[i+MB]=t[i];
-        }       
+        }
     }
 
     pub fn frombytes(bf: &[u8]) -> FP4 {
@@ -720,8 +720,8 @@ impl FP4 {
         c.geta().qr(h)
     }
 
-    // sqrt(a+ib) = sqrt(a+sqrt(a*a-n*b*b)/2)+ib/(2*sqrt(a+sqrt(a*a-n*b*b)/2)) 
-    // returns true if this is QR 
+    // sqrt(a+ib) = sqrt(a+sqrt(a*a-n*b*b)/2)+ib/(2*sqrt(a+sqrt(a*a-n*b*b)/2))
+    // returns true if this is QR
     pub fn sqrt(&mut self,h:Option<&FP>)  {
         if self.iszilch() {
             return;
@@ -774,7 +774,7 @@ impl FP4 {
         let sgn=self.sign();
         let mut nr=FP4::new_copy(&self);
         nr.neg(); nr.norm();
-        self.cmove(&nr,sgn); 
+        self.cmove(&nr,sgn);
     }
 PFGE24F */
 }

--- a/rust/fp8.rs
+++ b/rust/fp8.rs
@@ -38,7 +38,7 @@ impl std::fmt::Debug for FP8 {
     fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(formatter, "{}", self.tostring())
     }
-}    
+}
 impl std::fmt::Display for FP8 {
     fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(formatter, "{}", self.tostring())
@@ -95,7 +95,7 @@ impl FP8 {
         f
     }
 
-    pub fn new_rand(rng: &mut RAND) -> FP8 {
+    pub fn new_rand(rng: &mut impl RAND) -> FP8 {
         FP8::new_fp4s(&FP4::new_rand(rng),&FP4::new_rand(rng))
     }
 
@@ -157,7 +157,7 @@ impl FP8 {
         self.a.tobytes(&mut t);
         for i in 0..MB {
             bf[i+MB]=t[i];
-        }       
+        }
     }
 
     pub fn frombytes(bf: &[u8]) -> FP8 {
@@ -744,8 +744,8 @@ impl FP8 {
         return c.geta().qr(h);
     }
 
-    // sqrt(a+ib) = sqrt(a+sqrt(a*a-n*b*b)/2)+ib/(2*sqrt(a+sqrt(a*a-n*b*b)/2)) 
-    // returns true if this is QR 
+    // sqrt(a+ib) = sqrt(a+sqrt(a*a-n*b*b)/2)+ib/(2*sqrt(a+sqrt(a*a-n*b*b)/2))
+    // returns true if this is QR
     pub fn sqrt(&mut self,h:Option<&FP>) {
         if self.iszilch() {
             return;
@@ -797,7 +797,7 @@ impl FP8 {
         let sgn=self.sign();
         let mut nr=FP8::new_copy(&self);
         nr.neg(); nr.norm();
-        self.cmove(&nr,sgn); 
+        self.cmove(&nr,sgn);
     }
 PFGE48F */
 }

--- a/rust/hmac.rs
+++ b/rust/hmac.rs
@@ -282,7 +282,7 @@ pub fn hkdf_extract(hash: usize, hlen: usize, prk: &mut [u8],salt: Option<&[u8]>
     } else {
         let h: [u8; 64] = [0; 64];
         hmac1(hash,hlen,prk,hlen,&h[0..hlen],ikm);
-    }   
+    }
 }
 
 pub fn hkdf_expand(hash: usize, hlen: usize, okm: &mut [u8], olen: usize, prk: &[u8], info: &[u8]) {
@@ -362,7 +362,7 @@ pub fn xmd_expand(hash: usize,hlen: usize,okm: &mut [u8],olen: usize,dst: &[u8],
 		for j in 0..hlen {
 			h1[j]^=h0[j];
             h2[j]=h1[j];
-		}          
+		}
 		tmp[0]=i as u8;
 
 		for j in 0..dst.len() {
@@ -378,7 +378,7 @@ pub fn xmd_expand(hash: usize,hlen: usize,okm: &mut [u8],olen: usize,dst: &[u8],
                 break;
             }
         }
-    }        
+    }
 
 }
 
@@ -516,7 +516,7 @@ pub fn printbinary(array: &[u8]) {
     println!("")
 }
 */
-pub fn pss_encode(sha: usize, m: &[u8], rng: &mut RAND, f: &mut [u8], rfs: usize) -> bool {
+pub fn pss_encode(sha: usize, m: &[u8], rng: &mut impl RAND, f: &mut [u8], rfs: usize) -> bool {
     let emlen=rfs;
     let embits=8*emlen-1;
     let hlen=sha;
@@ -625,7 +625,7 @@ pub fn pss_verify(sha: usize, m: &[u8],f: &[u8]) -> bool {
     true
 }
 /* OAEP Message Encoding for Encryption */
-pub fn oaep_encode(sha: usize, m: &[u8], rng: &mut RAND, p: Option<&[u8]>, f: &mut [u8], rfs: usize) -> bool {
+pub fn oaep_encode(sha: usize, m: &[u8], rng: &mut impl RAND, p: Option<&[u8]>, f: &mut [u8], rfs: usize) -> bool {
     let olen = rfs - 1;
     let mlen = m.len();
 

--- a/rust/hpke.rs
+++ b/rust/hpke.rs
@@ -21,8 +21,9 @@ use crate::xxx::ecp;
 use crate::xxx::ecdh;
 
 use crate::hmac;
+use crate::rand::RAND_impl;
 
-const GROUP: usize = ecdh::EGS;  
+const GROUP: usize = ecdh::EGS;
 const POINT: usize = 2*ecdh::EFS+1;
 
 const MAX_LABEL: usize = 20;                // may need adjustment
@@ -119,7 +120,7 @@ fn extractAndExpand(config_id: usize,okm: &mut [u8],dh: &[u8],context: &[u8]) {
         k+=1;
     }
     suite_id[k]=kem_id[0]; k+=1;
-    suite_id[k]=kem_id[1]; 
+    suite_id[k]=kem_id[1];
 
     let mut prk: [u8;ecp::HASH_TYPE]=[0;ecp::HASH_TYPE];
     labeledExtract(&mut prk,None,&suite_id,"eae_prk",Some(dh));
@@ -141,7 +142,7 @@ pub fn deriveKeyPair(config_id: usize,mut sk: &mut [u8],mut pk: &mut [u8],seed: 
         k+=1;
     }
     suite_id[k]=kem_id[0]; k+=1;
-    suite_id[k]=kem_id[1]; 
+    suite_id[k]=kem_id[1];
 
     let mut prk: [u8;ecp::HASH_TYPE]=[0;ecp::HASH_TYPE];
     labeledExtract(&mut prk,None,&suite_id,"dkp_prk",Some(&seed));
@@ -173,7 +174,7 @@ pub fn deriveKeyPair(config_id: usize,mut sk: &mut [u8],mut pk: &mut [u8],seed: 
             counter += 1;
         }
     }
-    ecdh::key_pair_generate(None, &mut sk, &mut pk);
+    ecdh::key_pair_generate(None::<&mut RAND_impl>, &mut sk, &mut pk);
     if kem==32 || kem==33 {
         reverse(&mut pk);
     }
@@ -231,7 +232,7 @@ pub fn decap(config_id: usize,skR: &[u8],z: &mut [u8],pkE: &[u8],pkR: &[u8]) {
     }
 
     let mut k=0;
-    for i in 0..pklen {   
+    for i in 0..pklen {
         kemcontext[k]=pkE[i];
         k+=1;
     }
@@ -349,7 +350,7 @@ pub fn keyschedule(config_id: usize,key: &mut [u8],nonce: &mut [u8],exp_secret: 
     suite_id[k]=num[1]; k+=1;
     hmac::inttobytes(aead,&mut num);
     suite_id[k]=num[0]; k+=1;
-    suite_id[k]=num[1]; 
+    suite_id[k]=num[1];
 
     let mut k=0;
     let mut h: [u8; 64] = [0; 64];
@@ -360,14 +361,14 @@ pub fn keyschedule(config_id: usize,key: &mut [u8],nonce: &mut [u8],exp_secret: 
     labeledExtract(&mut h,None,&suite_id,"psk_id_hash",pskID);
     for i in 0..ecp::HASH_TYPE {
 		context[k] = h[i]; k+=1;
-    }  
+    }
     labeledExtract(&mut h,None,&suite_id,"info_hash",Some(&info));
     for i in 0..ecp::HASH_TYPE {
 		context[k] = h[i]; k+=1;
     }
 
     //labeledExtract(&mut h,None,&suite_id,"psk_hash",psk);
-    
+
     //labeledExtract(&mut secret,Some(&h),&suite_id,"secret",Some(z));
 
     labeledExtract(&mut secret,Some(z),&suite_id,"secret",psk);

--- a/rust/mpin.rs
+++ b/rust/mpin.rs
@@ -71,14 +71,14 @@ pub fn encode_to_curve(dst: &[u8],id: &[u8],hcid: &mut [u8]) {
     let u=FP::new_big(&dx.dmod(&q));
     let mut P=ECP::map2point(&u);
     P.cfp();
-    P.affine(); 
+    P.affine();
     P.tobytes(hcid,false);
 }
 
 /* create random secret S */
-pub fn random_generate(mut rng: &mut RAND, s: &mut [u8]) -> isize {
+pub fn random_generate(rng: &mut impl RAND, s: &mut [u8]) -> isize {
     let r = BIG::new_ints(&rom::CURVE_ORDER);
-    let sc = BIG::randtrunc(&r, 16 * ecp::AESKEY, &mut rng);
+    let sc = BIG::randtrunc(&r, 16 * ecp::AESKEY, rng);
     sc.tobytes(s);
     0
 }
@@ -137,7 +137,7 @@ pub fn get_client_secret(s: &mut [u8], idhtc: &[u8], cst: &mut [u8]) -> isize {
 #[allow(non_snake_case)]
 pub fn client_1(
     cid: &[u8],
-    rng: Option<&mut RAND>,
+    rng: Option<&mut impl RAND>,
     x: &mut [u8],
     pin: usize,
     token: &[u8],

--- a/rust/mpin192.rs
+++ b/rust/mpin192.rs
@@ -71,14 +71,14 @@ pub fn encode_to_curve(dst: &[u8],id: &[u8],hcid: &mut [u8]) {
     let u=FP::new_big(&dx.dmod(&q));
     let mut P=ECP::map2point(&u);
     P.cfp();
-    P.affine(); 
+    P.affine();
     P.tobytes(hcid,false);
 }
 
 /* create random secret S */
-pub fn random_generate(mut rng: &mut RAND, s: &mut [u8]) -> isize {
+pub fn random_generate(rng: &mut impl RAND, s: &mut [u8]) -> isize {
     let r = BIG::new_ints(&rom::CURVE_ORDER);
-    let sc = BIG::randtrunc(&r, 16 * ecp::AESKEY, &mut rng);
+    let sc = BIG::randtrunc(&r, 16 * ecp::AESKEY, rng);
     sc.tobytes(s);
     0
 }
@@ -137,7 +137,7 @@ pub fn get_client_secret(s: &mut [u8], idhtc: &[u8], cst: &mut [u8]) -> isize {
 #[allow(non_snake_case)]
 pub fn client_1(
     cid: &[u8],
-    rng: Option<&mut RAND>,
+    rng: Option<&mut impl RAND>,
     x: &mut [u8],
     pin: usize,
     token: &[u8],

--- a/rust/mpin256.rs
+++ b/rust/mpin256.rs
@@ -71,14 +71,14 @@ pub fn encode_to_curve(dst: &[u8],id: &[u8],hcid: &mut [u8]) {
     let u=FP::new_big(&dx.dmod(&q));
     let mut P=ECP::map2point(&u);
     P.cfp();
-    P.affine(); 
+    P.affine();
     P.tobytes(hcid,false);
 }
 
 /* create random secret S */
-pub fn random_generate(mut rng: &mut RAND, s: &mut [u8]) -> isize {
+pub fn random_generate(rng: &mut impl RAND, s: &mut [u8]) -> isize {
     let r = BIG::new_ints(&rom::CURVE_ORDER);
-    let sc = BIG::randtrunc(&r, 16 * ecp::AESKEY, &mut rng);
+    let sc = BIG::randtrunc(&r, 16 * ecp::AESKEY, rng);
     sc.tobytes(s);
     0
 }
@@ -137,7 +137,7 @@ pub fn get_client_secret(s: &mut [u8], idhtc: &[u8], cst: &mut [u8]) -> isize {
 #[allow(non_snake_case)]
 pub fn client_1(
     cid: &[u8],
-    rng: Option<&mut RAND>,
+    rng: Option<&mut impl RAND>,
     x: &mut [u8],
     pin: usize,
     token: &[u8],

--- a/rust/nhs.rs
+++ b/rust/nhs.rs
@@ -454,7 +454,7 @@ fn decompress(array: &[u8], poly: &mut [i32]) {
 
 /* generate centered binomial distribution */
 
-fn error(rng: &mut RAND, poly: &mut [i32]) {
+fn error(rng: &mut impl RAND, poly: &mut [i32]) {
     for i in 0..DEGREE {
         let mut n1 = ((rng.getbyte() as i32) & 0xff) + (((rng.getbyte() as i32) & 0xff) << 8);
         let mut n2 = ((rng.getbyte() as i32) & 0xff) + (((rng.getbyte() as i32) & 0xff) << 8);
@@ -517,7 +517,7 @@ fn poly_hard_reduce(poly: &mut [i32]) {
 
 /* API files */
 
-pub fn server_1(mut rng: &mut RAND, sb: &mut [u8], ss: &mut [u8]) {
+pub fn server_1(rng: &mut impl RAND, sb: &mut [u8], ss: &mut [u8]) {
     let mut seed: [u8; 32] = [0; 32];
     let mut array: [u8; 1792] = [0; 1792];
     let mut s: [i32; DEGREE] = [0; DEGREE];
@@ -530,8 +530,8 @@ pub fn server_1(mut rng: &mut RAND, sb: &mut [u8], ss: &mut [u8]) {
 
     parse(&seed, &mut b);
 
-    error(&mut rng, &mut e);
-    error(&mut rng, &mut s);
+    error(rng, &mut e);
+    error(rng, &mut s);
 
     ntt(&mut s);
     ntt(&mut e);
@@ -558,7 +558,7 @@ pub fn server_1(mut rng: &mut RAND, sb: &mut [u8], ss: &mut [u8]) {
     }
 }
 
-pub fn client(mut rng: &mut RAND, sb: &[u8], uc: &mut [u8], okey: &mut [u8]) {
+pub fn client(rng: &mut impl RAND, sb: &[u8], uc: &mut [u8], okey: &mut [u8]) {
     let mut sh = SHA3::new(sha3::HASH256);
 
     let mut seed: [u8; 32] = [0; 32];
@@ -572,8 +572,8 @@ pub fn client(mut rng: &mut RAND, sb: &[u8], uc: &mut [u8], okey: &mut [u8]) {
     let mut k: [i32; DEGREE] = [0; DEGREE];
     let mut c: [i32; DEGREE] = [0; DEGREE];
 
-    error(&mut rng, &mut sd);
-    error(&mut rng, &mut ed);
+    error(rng, &mut sd);
+    error(rng, &mut ed);
 
     ntt(&mut sd);
     ntt(&mut ed);
@@ -608,7 +608,7 @@ pub fn client(mut rng: &mut RAND, sb: &[u8], uc: &mut [u8], okey: &mut [u8]) {
 
     poly_mul(&mut c, &sd);
     intt(&mut c);
-    error(&mut rng, &mut ed);
+    error(rng, &mut ed);
     poly_add(&mut c, &ed);
     poly_add(&mut c, &k);
 

--- a/rust/rand.rs
+++ b/rust/rand.rs
@@ -25,7 +25,17 @@ const RAND_NK: usize = 21;
 const RAND_NJ: usize = 6;
 const RAND_NV: usize = 8;
 
-pub struct RAND {
+pub trait RAND {
+    /* Initialize RNG with some real entropy from some external source */
+    fn seed(&mut self, rawlen: usize, raw: &[u8]);
+    /* get random byte */
+    fn getbyte(&mut self) -> u8;
+}
+
+// Marsaglia-Zaman random generator (https://projecteuclid.org/euclid.aoap/1177005878)
+// Analysis: https://ieeexplore.ieee.org/document/669305
+#[allow(non_camel_case_types)]
+pub struct RAND_impl {
     ira: [u32; RAND_NK], /* random number...   */
     rndptr: usize,
     borrow: u32,
@@ -33,9 +43,9 @@ pub struct RAND {
     pool: [u8; 32],
 }
 
-impl RAND {
-    pub fn new() -> RAND {
-        RAND {
+impl RAND_impl {
+    pub fn new() -> RAND_impl {
+        RAND_impl {
             ira: [0; RAND_NK],
             rndptr: 0,
             borrow: 0,
@@ -44,6 +54,7 @@ impl RAND {
         }
     }
 
+    #[allow(dead_code)]
     pub fn clean(&mut self) {
         self.pool_ptr = 0;
         self.rndptr = 0;
@@ -121,9 +132,10 @@ impl RAND {
             | (((b[1] as u32) & 0xff) << 8)
             | ((b[0] as u32) & 0xff)
     }
+}
 
-    /* Initialize RNG with some real entropy from some external source */
-    pub fn seed(&mut self, rawlen: usize, raw: &[u8]) {
+impl RAND for RAND_impl {
+    fn seed(&mut self, rawlen: usize, raw: &[u8]) {
         /* initialise from at least 128 byte string of raw random entropy */
         let mut b: [u8; 4] = [0; 4];
         let mut sh = HASH256::new();
@@ -145,14 +157,13 @@ impl RAND {
                 b[1] = digest[4 * i + 1];
                 b[2] = digest[4 * i + 2];
                 b[3] = digest[4 * i + 3];
-                self.sirand(RAND::pack(b));
+                self.sirand(RAND_impl::pack(b));
             }
         }
         self.fill_pool();
     }
 
-    /* get random byte */
-    pub fn getbyte(&mut self) -> u8 {
+    fn getbyte(&mut self) -> u8 {
         let r = self.pool[self.pool_ptr];
         self.pool_ptr += 1;
         if self.pool_ptr >= 32 {
@@ -166,7 +177,7 @@ impl RAND {
 /*
 fn main() {
     let mut raw : [u8;100]=[0;100];
-    let mut rng=RAND::new();
+    let mut rng=RAND_impl::new();
 
     rng.clean();
     for i in 0..100 {raw[i]=i as u8}

--- a/rust/rsa.rs
+++ b/rust/rsa.rs
@@ -60,7 +60,7 @@ pub fn new_public_key(m: usize) -> RsaPublicKey {
     }
 }
 
-pub fn key_pair(rng: &mut RAND, e: isize, prv: &mut RsaPrivateKey, pbc: &mut RsaPublicKey) {
+pub fn key_pair(rng: &mut impl RAND, e: isize, prv: &mut RsaPrivateKey, pbc: &mut RsaPublicKey) {
     /* IEEE1363 A16.11/A16.12 more or less */
     let n = pbc.n.getlen() / 2;
     let mut t = FF::new_int(n);

--- a/rust/share.rs
+++ b/rust/share.rs
@@ -83,7 +83,7 @@ fn add(x: u8,y: u8) -> u8 {
 
 fn inv(x: u8) -> u8 {
    let ix = (x as usize) & 0xff;
-   let lx = (LTAB[ix] as usize) & 0xff; 
+   let lx = (LTAB[ix] as usize) & 0xff;
    PTAB[255-lx]
 }
 
@@ -93,7 +93,7 @@ fn interpolate(n: usize, x: &[u8], y: &[u8]) -> u8 {
     for i in 0..n {
         let mut p=1 as u8;
         for j in 0..n {
-            if i!=j { 
+            if i!=j {
                 p=mul(p,mul(x[j],inv(add(x[i],x[j]))));
             }
         }
@@ -108,17 +108,14 @@ impl<'a> SHARE<'a> {
 /* input id - Unique share ID */
 /* input nsr - Number of shares required for recovery */
 /* input Message M to be shared */
-/* input Random seed R */
+/* input Random number generator rng to be used */
 /* return share structure */
 // must bind lifetime of the byte array stored by structure, to lifetime of s
-    pub fn new(ident: usize,numshare: usize,s: &'a mut [u8],m: &[u8], r:&[u8]) -> SHARE<'a> {
+    pub fn new(ident: usize,numshare: usize,s: &'a mut [u8],m: &[u8], rng: &mut impl RAND) -> SHARE<'a> {
         if ident<1 || ident>=256 || numshare<2 || numshare>=256 {
             return SHARE{id:0,nsr:0,b:s};
         }
         let len=m.len();
-        let mut rng = RAND::new();
-        rng.clean();
-        rng.seed(r.len(),r);
         for j in 0..len {
             let mut x=ident as u8;
             s[j]=m[j];
@@ -126,9 +123,9 @@ impl<'a> SHARE<'a> {
                 s[j]=add(s[j],mul(rng.getbyte(),x));
                 x=mul(x,ident as u8);
             }
-        }        
+        }
         SHARE{id: ident as u8,nsr: numshare as u8,b:s}
-    } 
+    }
 /* recover M from shares */
     pub fn recover(m: &mut [u8],s: &[SHARE]) {
         let len=s[0].b.len();


### PR DESCRIPTION
Turning `miracl_core::rand::RAND` to a trait, to enable use of custom random number generators in miracl.
Renaming the existing implementation of `RAND` (Marsaglia-Zaman) to `RAND_impl`.
Removing a bunch of superfluous `mut`s.

Tested using `python3 config32.py test` and `python3 config64.py test`.