### PR TITLE
Rust xmd_expand: support long DSTs.

### DIFF
--- a/rust/hmac.rs
+++ b/rust/hmac.rs
@@ -341,6 +341,17 @@ pub fn xof_expand(hlen: usize,okm: &mut [u8],olen: usize,dst: &[u8],msg: &[u8]) 
 }
 
 pub fn xmd_expand(hash: usize,hlen: usize,okm: &mut [u8],olen: usize,dst: &[u8],msg: &[u8]) {
+    if dst.len() >= 256 {
+        let mut w = vec![0;hlen];
+        GPhashit(hash, hlen, &mut w, 0, 0, Some(b"H2C-OVERSIZE-DST-"), -1, Some(&dst));
+        xmd_expand_short_dst(hash, hlen, okm, olen, &w, msg);
+    } else {
+        xmd_expand_short_dst(hash, hlen, okm, olen, dst, msg);
+    }
+}
+
+// Assumes dst.len() < 256.
+fn xmd_expand_short_dst(hash: usize,hlen: usize,okm: &mut [u8],olen: usize,dst: &[u8],msg: &[u8]) {
     let mut tmp: [u8; 260] = [0; 260];
     let mut h0: [u8; 64]=[0;64];
     let mut h1: [u8; 64]=[0;64];


### PR DESCRIPTION
I tested the change on a test case from the spec: https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-12.html:

```
    let dst = b"QUUX-V01-CS02-with-expander-SHA256-128-long-DST-1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111";
    let msg = b"";
    let mut okm: [u8;512]=[0;512];
    hmac::xmd_expand(hmac::MC_SHA2,32,&mut okm,32,dst,msg);
    println!("{:?}", &okm);
```

but I didn't include this code in the commit because I'm not sure where it goes.