### PR TITLE
fix: unify rust `cfg` (`std` vs `no_std`)

### DIFF
--- a/rust/big.rs
+++ b/rust/big.rs
@@ -292,8 +292,7 @@ impl BIG {
     }
 
     /* Convert to Hex String */
-//#[cfg(feature = "std")]
-#[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     pub fn tostring(&self) -> String {
         let mut s = String::new();
         let mut len = self.nbits();
@@ -317,7 +316,7 @@ impl BIG {
         s
     }
 
-#[cfg(feature = "std")]
+    #[cfg(feature = "std")]
     pub fn fromstring(val: String) -> BIG {
         let mut res = BIG::new();
         let len = val.len();

--- a/rust/dbig.rs
+++ b/rust/dbig.rs
@@ -292,7 +292,7 @@ impl DBIG {
     }
 
     /* Convert to Hex String */
-#[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     pub fn tostring(&self) -> String {
         let mut s = String::new();
         let mut len = self.nbits();

--- a/rust/ecp.rs
+++ b/rust/ecp.rs
@@ -505,7 +505,7 @@ impl ECP {
     }
 
     /* convert to hex string */
-#[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     pub fn tostring(&self) -> String {
         let mut W = ECP::new();
         W.copy(self);

--- a/rust/ecp2.rs
+++ b/rust/ecp2.rs
@@ -324,7 +324,7 @@ impl ECP2 {
     }
 
     /* convert this to hex string */
-#[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     pub fn tostring(&self) -> String {
         let mut W = ECP2::new();
         W.copy(self);

--- a/rust/ecp4.rs
+++ b/rust/ecp4.rs
@@ -325,7 +325,7 @@ impl ECP4 {
     }
 
     /* convert this to hex string */
-#[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     pub fn tostring(&self) -> String {
         let mut W = ECP4::new();
         W.copy(self);

--- a/rust/ecp8.rs
+++ b/rust/ecp8.rs
@@ -326,7 +326,7 @@ impl ECP8 {
     }
 
     /* convert this to hex string */
-#[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     pub fn tostring(&self) -> String {
         let mut W = ECP8::new();
         W.copy(self);

--- a/rust/ff.rs
+++ b/rust/ff.rs
@@ -165,7 +165,7 @@ impl SF {
     }
 
     /* Convert to Hex String */
-#[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     pub fn tostring(&self) -> String {
         let mut cs:[BIG;SL]=[BIG::new();SL];
         return generic_tostring(&self.v,&mut cs,SL);
@@ -666,7 +666,7 @@ impl DF {
     }
 
     /* Convert to Hex String */
-#[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     pub fn tostring(&self) -> String {
         let mut cs:[BIG;DL]=[BIG::new();DL];
         return generic_tostring(&self.v,&mut cs,DL);
@@ -942,7 +942,7 @@ impl QF {
     }
 }
 
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 fn generic_tostring(v: &[BIG],cs: &mut [BIG],len: usize) -> String {
     generic_copy(cs,v);
     generic_norm(cs);

--- a/rust/fp.rs
+++ b/rust/fp.rs
@@ -209,7 +209,7 @@ impl FP {
     }
 
     /* convert to string */
-#[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     pub fn tostring(&self) -> String {
         self.redc().tostring()
     }

--- a/rust/fp12.rs
+++ b/rust/fp12.rs
@@ -907,7 +907,7 @@ impl FP12 {
     }
 
     /* output to hex string */
-#[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     pub fn tostring(&self) -> String {
         format!(
             "[{},{},{}]",

--- a/rust/fp16.rs
+++ b/rust/fp16.rs
@@ -337,7 +337,7 @@ impl FP16 {
     }
 
     /* output to hex string */
-#[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     pub fn tostring(&self) -> String {
         format!("[{},{}]", self.a.tostring(), self.b.tostring())
     }

--- a/rust/fp2.rs
+++ b/rust/fp2.rs
@@ -449,7 +449,7 @@ impl FP2 {
     }
 
     /* output to hex string */
-#[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     pub fn tostring(&self) -> String {
         format!("[{},{}]", self.a.tostring(), self.b.tostring())
     }

--- a/rust/fp24.rs
+++ b/rust/fp24.rs
@@ -917,7 +917,7 @@ impl FP24 {
     }
 
     /* output to hex string */
-#[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     pub fn tostring(&self) -> String {
         format!(
             "[{},{},{}]",

--- a/rust/fp4.rs
+++ b/rust/fp4.rs
@@ -388,7 +388,7 @@ impl FP4 {
     }
 
     /* output to hex string */
-#[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     pub fn tostring(&self) -> String {
         format!("[{},{}]", self.a.tostring(), self.b.tostring())
     }

--- a/rust/fp48.rs
+++ b/rust/fp48.rs
@@ -921,7 +921,7 @@ impl FP48 {
     }
 
     /* output to hex string */
-#[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     pub fn tostring(&self) -> String {
         format!(
             "[{},{},{}]",

--- a/rust/fp8.rs
+++ b/rust/fp8.rs
@@ -388,7 +388,7 @@ impl FP8 {
     }
 
     /* output to hex string */
-#[cfg(not(feature = "no_std"))]
+    #[cfg(feature = "std")]
     pub fn tostring(&self) -> String {
         format!("[{},{}]", self.a.tostring(), self.b.tostring())
     }

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-//#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 #![allow(clippy::many_single_char_names)]
 #![allow(clippy::needless_range_loop)]


### PR DESCRIPTION
Replace all instances of `feature = "no_std"`
Enable `no_std` using `cfg_attr`

This should improve the rust ergonomics.