### PR TITLE
Address more clippy lints

### DIFF
--- a/rust/dilithium.rs
+++ b/rust/dilithium.rs
@@ -490,6 +490,7 @@ fn unpack_pk(params: &[usize], rho: &mut [u8], t1: &mut [i16], pk: &[u8]) {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn pack_sk(
     params: &[usize],
     sk: &mut [u8],
@@ -538,6 +539,7 @@ fn pack_sk(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn unpack_sk(
     params: &[usize],
     rho: &mut [u8],

--- a/rust/dilithium.rs
+++ b/rust/dilithium.rs
@@ -469,8 +469,8 @@ fn pack_pk(params: &[usize], pk: &mut [u8], rho: &[u8], t1: &[i16]) {
     for i in 0..32 {
         pk[i] = rho[i];
     }
-    let mut ptr = 0 as usize;
-    let mut bts = 0 as usize;
+    let mut ptr = 0;
+    let mut bts = 0;
     let mut n = 32;
     for _ in 0..(ck * DEGREE * TD) / 8 {
         pk[n] = nextbyte16(TD, 0, t1, &mut ptr, &mut bts);
@@ -483,8 +483,8 @@ fn unpack_pk(params: &[usize], rho: &mut [u8], t1: &mut [i16], pk: &[u8]) {
     for i in 0..32 {
         rho[i] = pk[i];
     }
-    let mut ptr = 0 as usize;
-    let mut bts = 0 as usize;
+    let mut ptr = 0;
+    let mut bts = 0;
     for i in 0..ck * DEGREE {
         t1[i] = nextword(TD, 0, &pk[32..], &mut ptr, &mut bts) as i16;
     }
@@ -517,8 +517,8 @@ fn pack_sk(
         sk[n] = tr[i];
         n += 1;
     }
-    let mut ptr = 0 as usize;
-    let mut bts = 0 as usize;
+    let mut ptr = 0;
+    let mut bts = 0;
 
     for _ in 0..(el * DEGREE * lg2eta1) / 8 {
         sk[n] = nextbyte8(lg2eta1, eta, s1, &mut ptr, &mut bts);
@@ -565,8 +565,8 @@ fn unpack_sk(
         tr[i] = sk[n];
         n += 1;
     }
-    let mut ptr = 0 as usize;
-    let mut bts = 0 as usize;
+    let mut ptr = 0;
+    let mut bts = 0;
 
     for i in 0..el * DEGREE {
         s1[i] = nextword(lg2eta1, eta, &sk[n..], &mut ptr, &mut bts) as i8;
@@ -597,8 +597,8 @@ fn pack_sig(params: &[usize], sig: &mut [u8], z: &mut [i32], ct: &[u8], h: &[u8]
         sig[i] = ct[i];
     }
     let mut n = 32;
-    let mut ptr = 0 as usize;
-    let mut bts = 0 as usize;
+    let mut ptr = 0;
+    let mut bts = 0;
 
     for i in 0..el {
         let row = DEGREE * i;
@@ -632,8 +632,8 @@ fn unpack_sig(params: &[usize], z: &mut [i32], ct: &mut [u8], h: &mut [u8], sig:
         ct[i] = sig[i];
     }
 
-    let mut ptr = 0 as usize;
-    let mut bts = 0 as usize;
+    let mut ptr = 0;
+    let mut bts = 0;
 
     for i in 0..el * DEGREE {
         let mut t = nextword(lg + 1, 0, &sig[32..], &mut ptr, &mut bts);
@@ -663,8 +663,8 @@ fn sample_sn(params: &[usize], rhod: &[u8], s: &mut [i8], n: usize) {
     let eta = params[5];
     let lg2eta1 = params[6];
 
-    let mut ptr = 0 as usize;
-    let mut bts = 0 as usize;
+    let mut ptr = 0;
+    let mut bts = 0;
     for m in 0..DEGREE {
         loop {
             s[m] = nextword(lg2eta1, 0, &buff, &mut ptr, &mut bts) as i8;
@@ -692,8 +692,8 @@ fn sample_y(params: &[usize], k: usize, rhod: &[u8], y: &mut [i32]) {
         sh.process((ki >> 8) as u8);
         sh.shake(&mut buff, ((lg + 1) * DEGREE) / 8);
 
-        let mut ptr = 0 as usize;
-        let mut bts = 0 as usize;
+        let mut ptr = 0;
+        let mut bts = 0;
 
         for m in 0..DEGREE {
             let mut w = nextword(lg + 1, 0, &buff, &mut ptr, &mut bts);
@@ -710,8 +710,8 @@ fn crh1(params: &[usize], h: &mut [u8], rho: &[u8], t1: &[i16]) {
         sh.process(rho[j]);
     }
     let ck = params[3];
-    let mut ptr = 0 as usize;
-    let mut bts = 0 as usize;
+    let mut ptr = 0;
+    let mut bts = 0;
 
     for _ in 0..(ck * DEGREE * TD) / 8 {
         sh.process(nextbyte16(TD, 0, t1, &mut ptr, &mut bts));
@@ -753,8 +753,8 @@ fn h4(params: &[usize], ct: &mut [u8], mu: &[u8], w1: &[i8]) {
         sh.process(mu[j]);
     }
 
-    let mut ptr = 0 as usize;
-    let mut bts = 0 as usize;
+    let mut ptr = 0;
+    let mut bts = 0;
 
     for _ in 0..(ck * DEGREE * w1b) / 8 {
         sh.process(nextbyte8(w1b, 0, w1, &mut ptr, &mut bts));
@@ -801,7 +801,7 @@ fn sampleinball(params: &[usize], ct: &[u8], c: &mut [i32]) {
 }
 
 fn p2r(r0: &mut i32) -> i16 {
-    let d = (1 << D) as i32;
+    let d = 1 << D;
     let r1 = (*r0 + d / 2 - 1) >> D;
     *r0 -= r1 << D;
     r1 as i16
@@ -919,7 +919,7 @@ fn usepartialhint(
 }
 
 fn infinity_norm(w: &[i32]) -> i32 {
-    let mut n = 0 as i32;
+    let mut n = 0i32;
     for m in 0..DEGREE {
         let mut az = w[m];
         if az > PRIME / 2 {
@@ -1015,7 +1015,7 @@ fn signature(params: &[usize], sk: &[u8], m: &[u8], sig: &mut [u8]) -> usize {
 
     let tau = params[0];
     let lg = params[1];
-    let gamma1 = (1 << lg) as i32;
+    let gamma1 = 1 << lg;
     let dv = params[2] as i32;
     let gamma2 = (PRIME - 1) / dv;
     let ck = params[3];
@@ -1148,7 +1148,7 @@ fn verify(params: &[usize], pk: &[u8], m: &[u8], sig: &[u8]) -> bool {
 
     let tau = params[0];
     let lg = params[1];
-    let gamma1 = (1 << lg) as i32;
+    let gamma1 = 1 << lg;
     let ck = params[3];
     let el = params[4];
     let eta = params[5];

--- a/rust/dilithium.rs
+++ b/rust/dilithium.rs
@@ -1193,7 +1193,7 @@ fn verify(params: &[usize], pk: &[u8], m: &[u8], sig: &[u8]) -> bool {
         poly_sub(&mut r, &w);
         intt(&mut r);
 
-        hints = usepartialhint(params, &mut w1d[row..], &mut hint, hints, i, &r);
+        hints = usepartialhint(params, &mut w1d[row..], &hint, hints, i, &r);
         if hints > omega {
             return false;
         }

--- a/rust/dilithium.rs
+++ b/rust/dilithium.rs
@@ -1025,7 +1025,7 @@ fn signature(params: &[usize], sk: &[u8], m: &[u8], sig: &mut [u8]) -> usize {
     let omega = params[7];
 
     unpack_sk(
-        params, &mut rho, &mut bk, &mut tr, &mut s1, &mut s2, &mut t0, &sk,
+        params, &mut rho, &mut bk, &mut tr, &mut s1, &mut s2, &mut t0, sk,
     );
 
     // signature

--- a/rust/gcm.rs
+++ b/rust/gcm.rs
@@ -393,34 +393,30 @@ impl GCM {
         self.a.end();
     }
 
+    /// Convert a hex-encoded byte sequence to binary
     pub fn hex2bytes(hex: &[u8], bin: &mut [u8]) {
         let len = hex.len();
 
         for i in 0..len / 2 {
             let mut v: u8;
-            let mut c = hex[2 * i];
-            if c >= b'0' && c <= b'9' {
-                v = c - b'0';
-            } else if c >= b'A' && c <= b'F' {
-                v = c - b'A' + 10;
-            } else if c >= b'a' && c <= b'f' {
-                v = c - b'a' + 10;
-            } else {
-                v = 0;
-            }
+            v = hexchar2nibble(hex[2 * i]);
             v <<= 4;
-            c = hex[2 * i + 1];
-            if c >= b'0' && c <= b'9' {
-                v += c - b'0';
-            } else if c >= b'A' && c <= b'F' {
-                v += c - b'A' + 10;
-            } else if c >= b'a' && c <= b'f' {
-                v += c - b'a' + 10;
-            } else {
-                v = 0;
-            }
+            v += hexchar2nibble(hex[2 * i + 1]);
             bin[i] = v;
         }
+    }
+}
+
+/// Convert an ASCII hex character to the corresponding integer value
+///
+/// Helper function for `GCM::hex2bytes`.
+/// Returns a u8 in the range 0..=0xf.
+fn hexchar2nibble(c: u8) -> u8 {
+    match c {
+        b'0'..=b'9' => c - b'0',
+        b'A'..=b'F' => c - b'A' + 10,
+        b'a'..=b'f' => c - b'a' + 10,
+        _ => 0,
     }
 }
 

--- a/rust/hmac.rs
+++ b/rust/hmac.rs
@@ -381,7 +381,7 @@ pub fn xmd_expand(hash: usize, hlen: usize, okm: &mut [u8], olen: usize, dst: &[
             0,
             Some(b"H2C-OVERSIZE-DST-"),
             -1,
-            Some(&dst),
+            Some(dst),
         );
         xmd_expand_short_dst(hash, hlen, okm, olen, &w[0..hlen], msg);
     } else {

--- a/rust/hmac.rs
+++ b/rust/hmac.rs
@@ -656,7 +656,7 @@ pub fn pss_encode(sha: usize, m: &[u8], rng: &mut RAND, f: &mut [u8], rfs: usize
     for i in 0..hlen {
         salt[i] = rng.getbyte()
     }
-    let mask = (0xff as u8) >> (8 * emlen - embits);
+    let mask = (0xffu8) >> (8 * emlen - embits);
     SPhashit(MC_SHA2, sha, &mut h, Some(m));
     if emlen < hlen + hlen + 2 {
         return false;
@@ -683,7 +683,7 @@ pub fn pss_encode(sha: usize, m: &[u8], rng: &mut RAND, f: &mut [u8], rfs: usize
     for i in 0..hlen {
         f[emlen + i - hlen - 1] = h[i];
     }
-    f[emlen - 1] = 0xbc as u8;
+    f[emlen - 1] = 0xbcu8;
     true
 }
 
@@ -696,13 +696,13 @@ pub fn pss_verify(sha: usize, m: &[u8], f: &[u8]) -> bool {
     let mut h: [u8; 64] = [0; 64];
     let mut salt: [u8; 64] = [0; 64];
     let mut md: [u8; 136] = [0; 136];
-    let mask = (0xff as u8) >> (8 * emlen - embits);
+    let mask = (0xffu8) >> (8 * emlen - embits);
 
     SPhashit(MC_SHA2, sha, &mut hmask, Some(m));
     if emlen < hlen + hlen + 2 {
         return false;
     }
-    if f[emlen - 1] != 0xbc as u8 {
+    if f[emlen - 1] != 0xbcu8 {
         return false;
     }
     if (f[0] & (!mask)) != 0 {
@@ -717,7 +717,7 @@ pub fn pss_verify(sha: usize, m: &[u8], f: &[u8]) -> bool {
     mgf1xor(sha, &h[0..hlen], emlen - hlen - 1, &mut db);
     db[0] &= mask;
 
-    let mut k = 0 as u8;
+    let mut k = 0u8;
     for i in 0..emlen - hlen - hlen - 2 {
         k |= db[i]
     }

--- a/rust/kyber.rs
+++ b/rust/kyber.rs
@@ -123,7 +123,7 @@ fn ntt(r: &mut [i16]) {
 }
 
 fn invntt(r: &mut [i16]) {
-    let f = 1441 as i16;
+    let f = 1441i16;
     let mut k = 127;
     let mut len = 2;
     while len <= 128 {
@@ -244,8 +244,8 @@ fn getbit(b: &[u8], n: usize) -> i16 {
 
 fn cbd(bts: &[u8], eta: usize, f: &mut [i16]) {
     for i in 0..DEGREE {
-        let mut a = 0 as i16;
-        let mut b = 0 as i16;
+        let mut a = 0;
+        let mut b = 0;
         for j in 0..eta {
             a += getbit(bts, 2 * i * eta + j);
             b += getbit(bts, 2 * i * eta + eta + j);
@@ -307,7 +307,7 @@ fn encode(t: &[i16], len: usize, l: usize, pack: &mut [u8]) {
 fn chk_encode(t: &[i16], len: usize, l: usize, pack: &[u8]) -> u8 {
     let mut ptr = 0;
     let mut bts = 0;
-    let mut diff = 0 as u8;
+    let mut diff = 0;
     for n in 0..len * (DEGREE * l) / 8 {
         let m = nextbyte16(l, t, &mut ptr, &mut bts);
         diff |= m ^ pack[n];
@@ -326,7 +326,7 @@ fn decode(pack: &[u8], l: usize, t: &mut [i16], len: usize) {
 // Bernsteins safe division by 0xD01
 fn safediv(xx: i32) -> i32 {
     let mut x = xx;
-    let mut q = 0 as i32;
+    let mut q = 0;
 
     let mut qpart = (((x as i64) * 645083) >> 31) as i32;
     x -= qpart * 0xD01;
@@ -340,7 +340,7 @@ fn safediv(xx: i32) -> i32 {
 }
 
 fn compress(t: &mut [i16], len: usize, d: usize) {
-    let twod = (1 << d) as i32;
+    let twod = 1 << d;
     let dp = PRIME as i32;
     for i in 0..len * DEGREE {
         t[i] += (t[i] >> 15) & PRIME;
@@ -348,7 +348,7 @@ fn compress(t: &mut [i16], len: usize, d: usize) {
     }
 }
 fn decompress(t: &mut [i16], len: usize, d: usize) {
-    let twod1 = (1 << (d - 1)) as i32;
+    let twod1 = 1 << (d - 1);
     let dp = PRIME as i32;
     for i in 0..len * DEGREE {
         t[i] = ((dp * (t[i] as i32) + twod1) >> d) as i16;

--- a/rust/kyber.rs
+++ b/rust/kyber.rs
@@ -505,7 +505,7 @@ fn cpa_base_encrypt(
         poly_reduce(&mut u[row..]);
     }
 
-    decode(&pk, 12, &mut p, ck);
+    decode(pk, 12, &mut p, ck);
 
     poly_mul(v, &p, &q);
     for i in 1..ck {
@@ -524,7 +524,7 @@ fn cpa_base_encrypt(
 
     poly_acc(v, &w);
 
-    decode(&ss, 1, &mut r, 1);
+    decode(ss, 1, &mut r, 1);
     decompress(&mut r, 1, 1);
     poly_acc(v, &r);
     poly_reduce(v);
@@ -640,7 +640,7 @@ fn cca_encrypt(params: &[usize], randbytes32: &[u8], pk: &[u8], ss: &mut [u8], c
     sh.process_array(&hm);
     sh.process_array(&h);
     sh.hash(&mut g);
-    cpa_encrypt(params, &g[32..], &pk, &hm, ct);
+    cpa_encrypt(params, &g[32..], pk, &hm, ct);
 
     sh = SHA3::new(sha3::HASH256);
     for i in 0..ciphertext_size {
@@ -680,7 +680,7 @@ fn cca_decrypt(params: &[usize], sk: &[u8], ct: &[u8], ss: &mut [u8]) {
     }
 
     sh = SHA3::new(sha3::HASH256);
-    sh.process_array(&ct);
+    sh.process_array(ct);
     sh.hash(&mut m);
 
     sh = SHA3::new(sha3::SHAKE256);

--- a/rust/nhs.rs
+++ b/rust/nhs.rs
@@ -418,7 +418,7 @@ fn nhs_unpack(array: &[u8], poly: &mut [i32]) {
 /* See https://eprint.iacr.org/2016/1157.pdf */
 
 fn compress(poly: &[i32], array: &mut [u8]) {
-    let mut col = 0 as i32;
+    let mut col = 0i32;
     let mut j = 0;
     let mut i = 0;
     while i < DEGREE {
@@ -458,7 +458,7 @@ fn error(rng: &mut RAND, poly: &mut [i32]) {
     for i in 0..DEGREE {
         let mut n1 = ((rng.getbyte() as i32) & 0xff) + (((rng.getbyte() as i32) & 0xff) << 8);
         let mut n2 = ((rng.getbyte() as i32) & 0xff) + (((rng.getbyte() as i32) & 0xff) << 8);
-        let mut r = 0 as i32;
+        let mut r = 0i32;
         for _ in 0..16 {
             r += (n1 & 1) - (n2 & 1);
             n1 >>= 1;

--- a/rust/sha3.rs
+++ b/rust/sha3.rs
@@ -185,7 +185,7 @@ impl SHA3 {
     /* process a single byte */
     pub fn process(&mut self, byt: u8) {
         /* process the next message byte */
-        let cnt = self.length as usize;
+        let cnt = self.length;
         let b = cnt % 8;
         let ind = cnt / 8;
         self.s[ind] ^= (byt as u64) << (8 * b);
@@ -280,7 +280,7 @@ impl SHA3 {
             }
             self.process(0x80);
         }
-        let hlen = self.len as usize;
+        let hlen = self.len;
         self.squeeze(digest, hlen);
     }
 

--- a/rust/share.rs
+++ b/rust/share.rs
@@ -89,9 +89,9 @@ fn inv(x: u8) -> u8 {
 
 /* Lagrange interpolation */
 fn interpolate(n: usize, x: &[u8], y: &[u8]) -> u8 {
-    let mut yp = 0 as u8;
+    let mut yp = 0u8;
     for i in 0..n {
-        let mut p = 1 as u8;
+        let mut p = 1u8;
         for j in 0..n {
             if i != j {
                 p = mul(p, mul(x[j], inv(add(x[i], x[j]))));

--- a/rust/x509.rs
+++ b/rust/x509.rs
@@ -1002,15 +1002,16 @@ pub fn find_issuer(c: &[u8]) -> FDTYPE {
 
 pub fn find_validity(c: &[u8]) -> usize {
     let pos = find_issuer(c);
-    let j = pos.index + pos.length; // skip issuer
+    pos.index + pos.length // skip issuer
 
+    //let j = pos.index + pos.length;
     //let mut j=find_issuer(c);
     //let len=getalen(SEQ,c,j);
     //if len==0 {
     //    return 0;
     //}
     //j+=skip(len)+len; // skip issuer
-    j
+    //j
 }
 
 pub fn find_subject(c: &[u8]) -> FDTYPE {

--- a/rust/x509.rs
+++ b/rust/x509.rs
@@ -182,7 +182,7 @@ impl FDTYPE {
 pub fn extract_private_key(c: &[u8], pk: &mut [u8]) -> PKTYPE {
     let mut soid: [u8; 12] = [0; 12];
     let mut ret = PKTYPE::new();
-    let mut j = 0 as usize;
+    let mut j = 0;
     let pklen = pk.len();
 
     let mut len = getalen(SEQ, c, j); // Check for expected SEQ clause, and get length
@@ -471,7 +471,7 @@ pub fn extract_private_key(c: &[u8], pk: &mut [u8]) -> PKTYPE {
 pub fn extract_cert_sig(sc: &[u8], sig: &mut [u8]) -> PKTYPE {
     let mut soid: [u8; 12] = [0; 12];
     let mut ret = PKTYPE::new();
-    let mut j = 0 as usize;
+    let mut j = 0;
     let mut len = getalen(SEQ, sc, j); // Check for expected SEQ clause, and get length
     let siglen = sig.len();
 

--- a/rust/x509.rs
+++ b/rust/x509.rs
@@ -960,7 +960,7 @@ pub fn extract_public_key(c: &[u8], key: &mut [u8]) -> PKTYPE {
     let mut ptr = 0;
     let pklen = find_public_key(c, &mut ptr); // ptr is pointer into certificate, at start of ASN.1 raw public key
     let cc = &c[ptr..ptr + pklen];
-    get_public_key(&cc, key)
+    get_public_key(cc, key)
 }
 
 pub fn find_issuer(c: &[u8]) -> FDTYPE {


### PR DESCRIPTION
Fix style issues with the Rust code to reduce the lint noise and make more serious issues easier to notice

- Remove redundant casts and use integer literals to specify types from initializers
- Remove unnecessary borrows when the type was already a reference or didn't need to be mutable.
- Mark two functions triggering the "too many arguments" lint as expected.
- Refactor `GCM::hex2bytes` to use range patterns

Follow up to #70. This still isn't everything, but I felt it was useful progress.