### PR TITLE
Fix config.py prompt recursion

### DIFF
--- a/arduino/config.py
+++ b/arduino/config.py
@@ -836,7 +836,6 @@ def interactive_prompt_input():
             if (userInput == ''):
                 return 0
             print("Non-integer input, select values between 1 and " + str(miracl_crypto.total_entries))
-            interactive_prompt_input()
 
 interactive_prompt_print()
 

--- a/arduino/config.py
+++ b/arduino/config.py
@@ -473,7 +473,7 @@ def curveset(nbt,tf,tc,base,m8,rz,mt,qi,ct,ca,pf,stw,sx,g2,ab,cs) :
             replace(fnameh,"ZZZ",tc)
             replace(fnameh,"YYY",tf)
             replace(fnameh,"XXX",bd)
- 
+
             fnamec="pair_"+tc+".cpp"
             fnameh="pair_"+tc+".h"
 
@@ -650,7 +650,7 @@ def curveset(nbt,tf,tc,base,m8,rz,mt,qi,ct,ca,pf,stw,sx,g2,ab,cs) :
 
             copy_file("pair8.cpp", fnamec)
             copy_file("pair8.h", fnameh)
-  
+
             replace(fnamec,"ZZZ",tc)
             replace(fnamec,"YYY",tf)
             replace(fnamec,"XXX",bd)

--- a/c/config16.py
+++ b/c/config16.py
@@ -636,7 +636,6 @@ def interactive_prompt_input():
             if (userInput == ''):
                 return 0
             print("Non-integer input, select values between 1 and " + str(miracl_crypto.total_entries))
-            interactive_prompt_input()
 
 interactive_prompt_print()
 while keep_querying and not testing:

--- a/c/config32.py
+++ b/c/config32.py
@@ -871,7 +871,6 @@ def interactive_prompt_input():
             if (userInput == ''):
                 return 0
             print("Non-integer input, select values between 1 and " + str(miracl_crypto.total_entries))
-            interactive_prompt_input()
 
 interactive_prompt_print()
 while keep_querying and not testing:

--- a/c/config32.py
+++ b/c/config32.py
@@ -712,7 +712,7 @@ def curveset(nbt,tf,tc,base,m8,rz,mt,qi,ct,ca,pf,stw,sx,g2,ab,cs) :
 
             copy_temp_file("pair8.c", fnamec)
             copy_keep_file("pair8.h", fnameh)
-  
+
             replace(fnamec,"ZZZ",tc)
             replace(fnamec,"YYY",tf)
             replace(fnamec,"XXX",bd)

--- a/c/config64.py
+++ b/c/config64.py
@@ -908,7 +908,6 @@ def interactive_prompt_input():
             if (userInput == ''):
                 return 0
             print("Non-integer input, select values between 1 and " + str(miracl_crypto.total_entries))
-            interactive_prompt_input()
 
 def usage():
     print("Usage: ./config64.py [OPTIONS] [ARGUMENTS]\n")

--- a/c/config64.py
+++ b/c/config64.py
@@ -515,7 +515,7 @@ def curveset(nbt,tf,tc,base,m8,rz,mt,qi,ct,ca,pf,stw,sx,g2,ab,cs) :
 
             copy_temp_file("fp12.c", fnamec)
             copy_keep_file("fp12.h", fnameh)
- 
+
             replace(fnamec,"YYY",tf)
             replace(fnamec,"XXX",bd)
             replace(fnamec,"ZZZ",tc)
@@ -557,7 +557,7 @@ def curveset(nbt,tf,tc,base,m8,rz,mt,qi,ct,ca,pf,stw,sx,g2,ab,cs) :
 
             copy_temp_file("mpin.c", fnamec)
             copy_keep_file("mpin.h", fnameh)
- 
+
             replace(fnamec,"ZZZ",tc)
             replace(fnamec,"YYY",tf)
             replace(fnamec,"XXX",bd)
@@ -586,7 +586,7 @@ def curveset(nbt,tf,tc,base,m8,rz,mt,qi,ct,ca,pf,stw,sx,g2,ab,cs) :
 
             copy_temp_file("fp8.c", fnamec)
             copy_keep_file("fp8.h", fnameh)
- 
+
             replace(fnamec,"YYY",tf)
             replace(fnamec,"XXX",bd)
             replace(fnamec,"ZZZ",tc)
@@ -657,7 +657,7 @@ def curveset(nbt,tf,tc,base,m8,rz,mt,qi,ct,ca,pf,stw,sx,g2,ab,cs) :
 
             copy_temp_file("bls192.c", fnamec)
             copy_keep_file("bls192.h", fnameh)
- 
+
             replace(fnamec,"ZZZ",tc)
             replace(fnamec,"YYY",tf)
             replace(fnamec,"XXX",bd)
@@ -673,7 +673,7 @@ def curveset(nbt,tf,tc,base,m8,rz,mt,qi,ct,ca,pf,stw,sx,g2,ab,cs) :
 
             copy_temp_file("fp8.c", fnamec)
             copy_keep_file("fp8.h", fnameh)
- 
+
             replace(fnamec,"YYY",tf)
             replace(fnamec,"XXX",bd)
             replace(fnamec,"ZZZ",tc)
@@ -703,7 +703,7 @@ def curveset(nbt,tf,tc,base,m8,rz,mt,qi,ct,ca,pf,stw,sx,g2,ab,cs) :
 
             copy_temp_file("fp16.c", fnamec)
             copy_keep_file("fp16.h", fnameh)
- 
+
             replace(fnamec,"YYY",tf)
             replace(fnamec,"XXX",bd)
             replace(fnamec,"ZZZ",tc)
@@ -718,7 +718,7 @@ def curveset(nbt,tf,tc,base,m8,rz,mt,qi,ct,ca,pf,stw,sx,g2,ab,cs) :
 
             copy_temp_file("fp48.c", fnamec)
             copy_keep_file("fp48.h", fnameh)
- 
+
             replace(fnamec,"YYY",tf)
             replace(fnamec,"XXX",bd)
             replace(fnamec,"ZZZ",tc)
@@ -733,7 +733,7 @@ def curveset(nbt,tf,tc,base,m8,rz,mt,qi,ct,ca,pf,stw,sx,g2,ab,cs) :
 
             copy_temp_file("pair8.c", fnamec)
             copy_keep_file("pair8.h", fnameh)
-  
+
             replace(fnamec,"ZZZ",tc)
             replace(fnamec,"YYY",tf)
             replace(fnamec,"XXX",bd)
@@ -761,7 +761,7 @@ def curveset(nbt,tf,tc,base,m8,rz,mt,qi,ct,ca,pf,stw,sx,g2,ab,cs) :
 
             copy_temp_file("bls256.c", fnamec)
             copy_keep_file("bls256.h", fnameh)
- 
+
             replace(fnamec,"ZZZ",tc)
             replace(fnamec,"YYY",tf)
             replace(fnamec,"XXX",bd)

--- a/cpp/config16.py
+++ b/cpp/config16.py
@@ -636,7 +636,6 @@ def interactive_prompt_input():
             if (userInput == ''):
                 return 0
             print("Non-integer input, select values between 1 and " + str(miracl_crypto.total_entries))
-            interactive_prompt_input()
 
 interactive_prompt_print()
 while keep_querying and not testing:

--- a/cpp/config32.py
+++ b/cpp/config32.py
@@ -872,7 +872,6 @@ def interactive_prompt_input():
             if (userInput == ''):
                 return 0
             print("Non-integer input, select values between 1 and " + str(miracl_crypto.total_entries))
-            interactive_prompt_input()
 
 interactive_prompt_print()
 while keep_querying and not testing:

--- a/cpp/config32.py
+++ b/cpp/config32.py
@@ -713,7 +713,7 @@ def curveset(nbt,tf,tc,base,m8,rz,mt,qi,ct,ca,pf,stw,sx,g2,ab,cs) :
 
             copy_temp_file("pair8.cpp", fnamec)
             copy_keep_file("pair8.h", fnameh)
-  
+
             replace(fnamec,"ZZZ",tc)
             replace(fnamec,"YYY",tf)
             replace(fnamec,"XXX",bd)

--- a/cpp/config64.py
+++ b/cpp/config64.py
@@ -909,7 +909,6 @@ def interactive_prompt_input():
             if (userInput == ''):
                 return 0
             print("Non-integer input, select values between 1 and " + str(miracl_crypto.total_entries))
-            interactive_prompt_input()
 
 def usage():
     print("Usage: ./config64.py [OPTIONS] [ARGUMENTS]\n")

--- a/go/config32.py
+++ b/go/config32.py
@@ -200,8 +200,8 @@ def curveset(tc,base,nbt,m8,rz,mt,qi,ct,ca,pf,stw,sx,g2,ab,cs) :
     replace(fpath+"CONFIG_CURVE.go","@AB@",ab)
     replace(fpath+"CONFIG_CURVE.go","@G2@",g2)
 
-    replace(fpath+"CONFIG_CURVE.go","@HC@",hc) 
-    replace(fpath+"CONFIG_CURVE.go","@HC2@",hc2) 
+    replace(fpath+"CONFIG_CURVE.go","@HC@",hc)
+    replace(fpath+"CONFIG_CURVE.go","@HC2@",hc2)
 
     if cs == "128" :
         replace(fpath+"CONFIG_CURVE.go","@HT@","32")
@@ -327,7 +327,7 @@ class miracl_crypto:
         ("TWEEDLEDUM","29","255","33","1","NOT_SPECIAL","5","WEIERSTRASS","0","NOT","NOT","NOT","NOT","NOT","128"),
         ("TWEEDLEDEE","29","255","34","1","NOT_SPECIAL","5","WEIERSTRASS","0","NOT","NOT","NOT","NOT","NOT","128")
     )
-    
+
 
     pf_curves = (
         ("BN254","28","254","1",["-1","-1","0"],"NOT_SPECIAL","0","WEIERSTRASS","0","BN","D_TYPE","NEGATIVEX","71","66","128"),

--- a/go/config32.py
+++ b/go/config32.py
@@ -408,7 +408,6 @@ def interactive_prompt_input():
             if (userInput == ''):
                 return 0
             print("Non-integer input, select values between 1 and " + str(miracl_crypto.total_entries))
-            interactive_prompt_input()
 
 
 interactive_prompt_print()

--- a/go/config64.py
+++ b/go/config64.py
@@ -407,7 +407,6 @@ def interactive_prompt_input():
             if (userInput == ''):
                 return 0
             print("Non-integer input, select values between 1 and " + str(miracl_crypto.total_entries))
-            interactive_prompt_input()
 
 
 interactive_prompt_print()

--- a/go/config64.py
+++ b/go/config64.py
@@ -201,8 +201,8 @@ def curveset(tc,base,nbt,m8,rz,mt,qi,ct,ca,pf,stw,sx,g2,ab,cs) :
     replace(fpath+"CONFIG_CURVE.go","@AB@",ab)
     replace(fpath+"CONFIG_CURVE.go","@G2@",g2)
 
-    replace(fpath+"CONFIG_CURVE.go","@HC@",hc) 
-    replace(fpath+"CONFIG_CURVE.go","@HC2@",hc2) 
+    replace(fpath+"CONFIG_CURVE.go","@HC@",hc)
+    replace(fpath+"CONFIG_CURVE.go","@HC2@",hc2)
 
     if cs == "128" :
         replace(fpath+"CONFIG_CURVE.go","@HT@","32")

--- a/java/config32.py
+++ b/java/config32.py
@@ -449,7 +449,6 @@ def interactive_prompt_input():
             if (userInput == ''):
                 return 0
             print("Non-integer input, select values between 1 and " + str(miracl_crypto.total_entries))
-            interactive_prompt_input()
 
 
 interactive_prompt_print()

--- a/java/config32.py
+++ b/java/config32.py
@@ -227,8 +227,8 @@ def curveset(tc,base,nbt,m8,rz,mt,qi,ct,ca,pf,stw,sx,g2,ab,cs) :
     replace(fpath+"CONFIG_CURVE.java","@AB@",ab)
     replace(fpath+"CONFIG_CURVE.java","@G2@",g2)
 
-    replace(fpath+"CONFIG_CURVE.java","@HC@",hc) 
-    replace(fpath+"CONFIG_CURVE.java","@HC2@",hc2) 
+    replace(fpath+"CONFIG_CURVE.java","@HC@",hc)
+    replace(fpath+"CONFIG_CURVE.java","@HC2@",hc2)
 
     if cs == "128" :
         replace(fpath+"CONFIG_CURVE.java","@HT@","32")

--- a/java/config64.py
+++ b/java/config64.py
@@ -446,7 +446,6 @@ def interactive_prompt_input():
             if (userInput == ''):
                 return 0
             print("Non-integer input, select values between 1 and " + str(miracl_crypto.total_entries))
-            interactive_prompt_input()
 
 
 interactive_prompt_print()

--- a/java/config64.py
+++ b/java/config64.py
@@ -227,8 +227,8 @@ def curveset(tc,base,nbt,m8,rz,mt,qi,ct,ca,pf,stw,sx,g2,ab,cs) :
     replace(fpath+"CONFIG_CURVE.java","@AB@",ab)
     replace(fpath+"CONFIG_CURVE.java","@G2@",g2)
 
-    replace(fpath+"CONFIG_CURVE.java","@HC@",hc) 
-    replace(fpath+"CONFIG_CURVE.java","@HC2@",hc2) 
+    replace(fpath+"CONFIG_CURVE.java","@HC@",hc)
+    replace(fpath+"CONFIG_CURVE.java","@HC2@",hc2)
 
     if cs == "128" :
         replace(fpath+"CONFIG_CURVE.java","@HT@","32")
@@ -372,7 +372,7 @@ class miracl_crypto:
         ("BN254","56","254","1",["-1","-1","0"],"NOT_SPECIAL","0","WEIERSTRASS","0","BN","D_TYPE","NEGATIVEX","71","66","128"),
         ("BN254CX","56","254","1",["-1","-1","0"],"NOT_SPECIAL","0","WEIERSTRASS","0","BN","D_TYPE","NEGATIVEX","76","66","128"),
         ("BLS12383","58","383","1",["1","1","0"],"NOT_SPECIAL","0","WEIERSTRASS","0","BLS12","M_TYPE","POSITIVEX","68","65","128"),
-        ("BLS12381","58","381","1",["11","-2","-1","11","3"],"NOT_SPECIAL","0","WEIERSTRASS","0","BLS12","M_TYPE","NEGATIVEX","69","65","128"), 
+        ("BLS12381","58","381","1",["11","-2","-1","11","3"],"NOT_SPECIAL","0","WEIERSTRASS","0","BLS12","M_TYPE","NEGATIVEX","69","65","128"),
         ("FP256BN","56","256","1",["1","1","0"],"NOT_SPECIAL","0","WEIERSTRASS","0","BN","M_TYPE","NEGATIVEX","83","66","128"),
         ("FP512BN","60","512","1",["1","1","0"],"NOT_SPECIAL","0","WEIERSTRASS","0","BN","M_TYPE","POSITIVEX","172","130","128"),
         ("BLS12443","60","443","1",["-7","1","1","11","3"],"NOT_SPECIAL","0","WEIERSTRASS","0","BLS12","M_TYPE","POSITIVEX","78","75","128"),

--- a/python/big.py
+++ b/python/big.py
@@ -41,11 +41,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-#   You can be released from the requirements of the license by purchasing     
+#   You can be released from the requirements of the license by purchasing
 #   a commercial license. Buying such a license is mandatory as soon as you
 #   develop commercial activities involving the MIRACL Core Crypto SDK
 #   without disclosing the source code of your own applications, or shipping
-#   the MIRACL Core Crypto SDK with a closed source product.     
+#   the MIRACL Core Crypto SDK with a closed source product.
 #
 
 # Number Theoretic functions

--- a/python/bls12381.py
+++ b/python/bls12381.py
@@ -41,11 +41,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-#   You can be released from the requirements of the license by purchasing     
+#   You can be released from the requirements of the license by purchasing
 #   a commercial license. Buying such a license is mandatory as soon as you
 #   develop commercial activities involving the MIRACL Core Crypto SDK
 #   without disclosing the source code of your own applications, or shipping
-#   the MIRACL Core Crypto SDK with a closed source product.     
+#   the MIRACL Core Crypto SDK with a closed source product.
 
 # BLS12381 curve constants
 

--- a/python/bls12443.py
+++ b/python/bls12443.py
@@ -41,11 +41,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-#   You can be released from the requirements of the license by purchasing     
+#   You can be released from the requirements of the license by purchasing
 #   a commercial license. Buying such a license is mandatory as soon as you
 #   develop commercial activities involving the MIRACL Core Crypto SDK
 #   without disclosing the source code of your own applications, or shipping
-#   the MIRACL Core Crypto SDK with a closed source product.     
+#   the MIRACL Core Crypto SDK with a closed source product.
 
 # BLS12443 curve constants
 

--- a/python/constants.py
+++ b/python/constants.py
@@ -41,15 +41,15 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-#   You can be released from the requirements of the license by purchasing     
+#   You can be released from the requirements of the license by purchasing
 #   a commercial license. Buying such a license is mandatory as soon as you
 #   develop commercial activities involving the MIRACL Core Crypto SDK
 #   without disclosing the source code of your own applications, or shipping
-#   the MIRACL Core Crypto SDK with a closed source product.     
+#   the MIRACL Core Crypto SDK with a closed source product.
 
 # fixed constants
 
-__all__ = ['WEIERSTRASS', 'EDWARDS', 'MONTGOMERY','D_TYPE','M_TYPE','NEGATIVEX','POSITIVEX','BN','BLS','ECDH_INVALID_PUBLIC_KEY','ECDH_ERROR'] 
+__all__ = ['WEIERSTRASS', 'EDWARDS', 'MONTGOMERY','D_TYPE','M_TYPE','NEGATIVEX','POSITIVEX','BN','BLS','ECDH_INVALID_PUBLIC_KEY','ECDH_ERROR']
 
 WEIERSTRASS = 0
 EDWARDS = 1

--- a/python/ecp2.py
+++ b/python/ecp2.py
@@ -41,11 +41,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-#   You can be released from the requirements of the license by purchasing     
+#   You can be released from the requirements of the license by purchasing
 #   a commercial license. Buying such a license is mandatory as soon as you
 #   develop commercial activities involving the MIRACL Core Crypto SDK
 #   without disclosing the source code of your own applications, or shipping
-#   the MIRACL Core Crypto SDK with a closed source product.     
+#   the MIRACL Core Crypto SDK with a closed source product.
 
 #
 # Elliptic Curve Points over Fp^2

--- a/python/fp.py
+++ b/python/fp.py
@@ -41,11 +41,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-#   You can be released from the requirements of the license by purchasing     
+#   You can be released from the requirements of the license by purchasing
 #   a commercial license. Buying such a license is mandatory as soon as you
 #   develop commercial activities involving the MIRACL Core Crypto SDK
 #   without disclosing the source code of your own applications, or shipping
-#   the MIRACL Core Crypto SDK with a closed source product.     
+#   the MIRACL Core Crypto SDK with a closed source product.
 
 #
 # bigs modulo n

--- a/python/fp12.py
+++ b/python/fp12.py
@@ -41,11 +41,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-#   You can be released from the requirements of the license by purchasing     
+#   You can be released from the requirements of the license by purchasing
 #   a commercial license. Buying such a license is mandatory as soon as you
 #   develop commercial activities involving the MIRACL Core Crypto SDK
 #   without disclosing the source code of your own applications, or shipping
-#   the MIRACL Core Crypto SDK with a closed source product.     
+#   the MIRACL Core Crypto SDK with a closed source product.
 
 #
 # Fp^12 CLass -  towered over Fp^4
@@ -250,7 +250,7 @@ class Fp12:
             tb=other.a.a+other.a.b
             tc=ta*tb
             tc-=(w1+w2)
-			
+
             ta=self.a.a+self.c.b
             tb=other.a.a+other.c.b
             td=ta*tb

--- a/python/fp2.py
+++ b/python/fp2.py
@@ -41,11 +41,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-#   You can be released from the requirements of the license by purchasing     
+#   You can be released from the requirements of the license by purchasing
 #   a commercial license. Buying such a license is mandatory as soon as you
 #   develop commercial activities involving the MIRACL Core Crypto SDK
 #   without disclosing the source code of your own applications, or shipping
-#   the MIRACL Core Crypto SDK with a closed source product.     
+#   the MIRACL Core Crypto SDK with a closed source product.
 
 #
 # Fp^2 CLass
@@ -207,13 +207,13 @@ class Fp2:
         while True :
             bt=z&1
             z >>= 1
-            if bt == 1: 
+            if bt == 1:
                 r *= w
             if z == 0 :
                 break
             w.sqr()
         return r.copy()
-    
+
     def qr(self):
         w=self.conj()
         w *= self
@@ -237,7 +237,7 @@ class Fp2:
         self.a = w2.copy()
         w2 += w2
         w2 = w2.inverse()
-        self.b *= w2 
+        self.b *= w2
 
 
 

--- a/python/fp4.py
+++ b/python/fp4.py
@@ -41,11 +41,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-#   You can be released from the requirements of the license by purchasing     
+#   You can be released from the requirements of the license by purchasing
 #   a commercial license. Buying such a license is mandatory as soon as you
 #   develop commercial activities involving the MIRACL Core Crypto SDK
 #   without disclosing the source code of your own applications, or shipping
-#   the MIRACL Core Crypto SDK with a closed source product.     
+#   the MIRACL Core Crypto SDK with a closed source product.
 
 #
 # Fp^4 CLass - towered over Fp^2

--- a/python/pair.py
+++ b/python/pair.py
@@ -41,11 +41,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-#   You can be released from the requirements of the license by purchasing     
+#   You can be released from the requirements of the license by purchasing
 #   a commercial license. Buying such a license is mandatory as soon as you
 #   develop commercial activities involving the MIRACL Core Crypto SDK
 #   without disclosing the source code of your own applications, or shipping
-#   the MIRACL Core Crypto SDK with a closed source product.     
+#   the MIRACL Core Crypto SDK with a closed source product.
 
 #
 # Optimal Ate Pairing
@@ -77,7 +77,7 @@ def dbl(A) :
     if curve.SexticTwist == D_TYPE:
         YY = YY.mulQNR()
         CC = CC.mulQNR()
-    if curve.SexticTwist == M_TYPE:    
+    if curve.SexticTwist == M_TYPE:
         BB = BB.mulQNR()
     BB=BB-YY
     A.dbl()
@@ -148,7 +148,7 @@ def miller(r) :
         res.conj()
     res *= r[0]
     return res
-	
+
 def pack(AA,BB,CC) :
     i=CC.inverse()
     return Fp4(AA*i,BB*i)
@@ -157,7 +157,7 @@ def unpack(T,Qx,Qy) :
     aa,bb=T.get()
     aa=aa.muls(Qy)
     a=Fp4(aa,bb)
-  
+
     t=Fp2(Qx)
     if curve.SexticTwist == D_TYPE:
         b=Fp4(t)
@@ -182,7 +182,7 @@ def precomp(GV) :
         if big.bit(n3, i) == 0 and big.bit(n, i) == 1:
             AA,BB,CC=add(A,MP)
             T.append(pack(AA,BB,CC))
-    
+
     if curve.PairingFriendly == BN:
         KA = P.copy()
         KA.frobenius()
@@ -196,14 +196,14 @@ def precomp(GV) :
         T.append(pack(AA,BB,CC))
     return T
 
-# Accumulate another set of line functions for n-pairing, assuming precomputation on G2 
+# Accumulate another set of line functions for n-pairing, assuming precomputation on G2
 def another_pc(r,T,QV) :
     if QV.isinf() :
         return
     nb,n3,n=lbits()
     Q=QV.copy()
     Q.affine()
-    Qx, Qy = Q.getxy()	
+    Qx, Qy = Q.getxy()
     j=0
     for i in range(nb - 2, 0, -1):
         lv=unpack(T[j],Qx,Qy)
@@ -212,7 +212,7 @@ def another_pc(r,T,QV) :
             lv2=unpack(T[j],Qx,Qy)
             j+=1
             lv.smul(lv2)
-        if big.bit(n3, i) == 0 and big.bit(n, i) == 1:        
+        if big.bit(n3, i) == 0 and big.bit(n, i) == 1:
             lv2=unpack(T[j],Qx,Qy)
             j+=1
             lv.smul(lv2)
@@ -225,7 +225,7 @@ def another_pc(r,T,QV) :
         lv.smul(lv2)
         r[0] *= lv
 
-# Accumulate another set of line functions for n-pairing 
+# Accumulate another set of line functions for n-pairing
 def another(r,P1,Q1) :
     if Q1.isinf() :
         return
@@ -236,7 +236,7 @@ def another(r,P1,Q1) :
     P.affine()
     Q.affine()
     A = P.copy()
-    Qx, Qy = Q.getxy()	
+    Qx, Qy = Q.getxy()
     for i in range(nb - 2, 0, -1):
         lv=g(A, A, Qx, Qy)
 
@@ -247,7 +247,7 @@ def another(r,P1,Q1) :
             lv2 = g(A, -P, Qx, Qy)
             lv.smul(lv2)
         r[i] *= lv
-    
+
     if curve.PairingFriendly == BN:
         KA = P.copy()
         KA.frobenius()
@@ -271,7 +271,7 @@ def ate(P1, Q1):
     if Q1.isinf() :
         return one();
     nb,n3,n=lbits()
-    
+
     P = P1.copy()
     Q = Q1.copy()
 

--- a/rust/config32.py
+++ b/rust/config32.py
@@ -384,7 +384,7 @@ def interactive_prompt_input():
             if (userInput == ''):
                 return 0
             print("Non-integer input, select values between 1 and " + str(miracl_crypto.total_entries))
-            interactive_prompt_input()
+
 
 if __name__ == '__main__':
     copytext="cp "

--- a/rust/config32.py
+++ b/rust/config32.py
@@ -178,8 +178,8 @@ def curveset(tc,base,nbt,m8,rz,mt,qi,ct,ca,pf,stw,sx,g2,ab,cs) :
     replace(fpath+"ecp.rs","@AB@",ab)
     replace(fpath+"ecp.rs","@G2@",g2)
 
-    replace(fpath+"ecp.rs","@HC@",hc) 
-    replace(fpath+"ecp.rs","@HC2@",hc2) 
+    replace(fpath+"ecp.rs","@HC@",hc)
+    replace(fpath+"ecp.rs","@HC2@",hc2)
 
     if cs == "128" :
         replace(fpath+"ecp.rs","@HT@","32")

--- a/rust/config64.py
+++ b/rust/config64.py
@@ -388,7 +388,7 @@ def interactive_prompt_input():
             if (userInput == ''):
                 return 0
             print("Non-integer input, select values between 1 and " + str(miracl_crypto.total_entries))
-            interactive_prompt_input()
+
 
 if __name__ == '__main__':
     copytext="cp "

--- a/rust/config64.py
+++ b/rust/config64.py
@@ -181,8 +181,8 @@ def curveset(tc,base,nbt,m8,rz,mt,qi,ct,ca,pf,stw,sx,g2,ab,cs) :
     replace(fpath+"ecp.rs","@AB@",ab)
     replace(fpath+"ecp.rs","@G2@",g2)
 
-    replace(fpath+"ecp.rs","@HC@",hc) 
-    replace(fpath+"ecp.rs","@HC2@",hc2) 
+    replace(fpath+"ecp.rs","@HC@",hc)
+    replace(fpath+"ecp.rs","@HC2@",hc2)
 
     if cs == "128" :
         replace(fpath+"ecp.rs","@HT@","32")
@@ -323,7 +323,7 @@ class miracl_crypto:
         ("bls48556","58","556","1",["-1","2","0"],"NOT_SPECIAL","0","WEIERSTRASS","0","BLS48","M_TYPE","POSITIVEX","35","32","256"),
         ("bls48581","60","581","1",["2","2","0"],"NOT_SPECIAL","10","WEIERSTRASS","0","BLS48","D_TYPE","NEGATIVEX","36","33","256"),
         ("bls48286","60","286","1",["1","1","0"],"NOT_SPECIAL","0","WEIERSTRASS","0","BLS48","M_TYPE","POSITIVEX","20","17","128"),
-        ("bn158","56","158","1",["1","1","0"],"NOT_SPECIAL","0","WEIERSTRASS","0","BN","M_TYPE","NEGATIVEX","49","42","128") 
+        ("bn158","56","158","1",["1","1","0"],"NOT_SPECIAL","0","WEIERSTRASS","0","BN","M_TYPE","NEGATIVEX","49","42","128")
     )
 
     rsa_params = (

--- a/swift/config32.py
+++ b/swift/config32.py
@@ -179,8 +179,8 @@ def curveset(tc,base,nbt,m8,rz,mt,qi,ct,ca,pf,stw,sx,ab,cs) :
     replace(fpath+"config_curve.swift","@SX@",sx)
     replace(fpath+"config_curve.swift","@AB@",ab)
 
-    replace(fpath+"config_curve.swift","@HC@",hc) 
-    replace(fpath+"config_curve.swift","@HC2@",hc2) 
+    replace(fpath+"config_curve.swift","@HC@",hc)
+    replace(fpath+"config_curve.swift","@HC2@",hc2)
 
     if cs == "128" :
         replace(fpath+"config_curve.swift","@HT@","32")

--- a/swift/config32.py
+++ b/swift/config32.py
@@ -377,7 +377,7 @@ def interactive_prompt_input():
             if (userInput == ''):
                 return 0
             print("Non-integer input, select values between 1 and " + str(miracl_crypto.total_entries))
-            interactive_prompt_input()
+
 
 interactive_prompt_print()
 while keep_querying and not testing:

--- a/swift/config64.py
+++ b/swift/config64.py
@@ -179,8 +179,8 @@ def curveset(tc,base,nbt,m8,rz,mt,qi,ct,ca,pf,stw,sx,ab,cs) :
     replace(fpath+"config_curve.swift","@SX@",sx)
     replace(fpath+"config_curve.swift","@AB@",ab)
 
-    replace(fpath+"config_curve.swift","@HC@",hc) 
-    replace(fpath+"config_curve.swift","@HC2@",hc2) 
+    replace(fpath+"config_curve.swift","@HC@",hc)
+    replace(fpath+"config_curve.swift","@HC2@",hc2)
 
     if cs == "128" :
         replace(fpath+"config_curve.swift","@HT@","32")

--- a/swift/config64.py
+++ b/swift/config64.py
@@ -375,7 +375,7 @@ def interactive_prompt_input():
             if (userInput == ''):
                 return 0
             print("Non-integer input, select values between 1 and " + str(miracl_crypto.total_entries))
-            interactive_prompt_input()
+
 
 interactive_prompt_print()
 while keep_querying and not testing:

--- a/wasm/config32.py
+++ b/wasm/config32.py
@@ -879,7 +879,7 @@ def interactive_prompt_input():
             if (userInput == ''):
                 return 0
             print("Non-integer input, select values between 1 and " + str(miracl_crypto.total_entries))
-            interactive_prompt_input()
+
 
 interactive_prompt_print()
 while keep_querying :

--- a/wasm/config32.py
+++ b/wasm/config32.py
@@ -718,7 +718,7 @@ def curveset(nbt,tf,tc,base,m8,rz,mt,qi,ct,ca,pf,stw,sx,g2,ab,cs) :
 
             copy_temp_file("pair8.c", fnamec)
             copy_keep_file("pair8.h", fnameh)
-  
+
             replace(fnamec,"ZZZ",tc)
             replace(fnamec,"YYY",tf)
             replace(fnamec,"XXX",bd)

--- a/wasm/config64.py
+++ b/wasm/config64.py
@@ -885,7 +885,7 @@ def interactive_prompt_input():
             if (userInput == ''):
                 return 0
             print("Non-integer input, select values between 1 and " + str(miracl_crypto.total_entries))
-            interactive_prompt_input()
+
 
 interactive_prompt_print()
 while keep_querying :

--- a/wasm/config64.py
+++ b/wasm/config64.py
@@ -491,7 +491,7 @@ def curveset(nbt,tf,tc,base,m8,rz,mt,qi,ct,ca,pf,stw,sx,g2,ab,cs) :
 
             copy_temp_file("fp12.c", fnamec)
             copy_keep_file("fp12.h", fnameh)
- 
+
             replace(fnamec,"YYY",tf)
             replace(fnamec,"XXX",bd)
             replace(fnamec,"ZZZ",tc)
@@ -536,7 +536,7 @@ def curveset(nbt,tf,tc,base,m8,rz,mt,qi,ct,ca,pf,stw,sx,g2,ab,cs) :
 
             copy_temp_file("mpin.c", fnamec)
             copy_keep_file("mpin.h", fnameh)
- 
+
             replace(fnamec,"ZZZ",tc)
             replace(fnamec,"YYY",tf)
             replace(fnamec,"XXX",bd)
@@ -567,7 +567,7 @@ def curveset(nbt,tf,tc,base,m8,rz,mt,qi,ct,ca,pf,stw,sx,g2,ab,cs) :
 
             copy_temp_file("fp8.c", fnamec)
             copy_keep_file("fp8.h", fnameh)
- 
+
             replace(fnamec,"YYY",tf)
             replace(fnamec,"XXX",bd)
             replace(fnamec,"ZZZ",tc)
@@ -642,7 +642,7 @@ def curveset(nbt,tf,tc,base,m8,rz,mt,qi,ct,ca,pf,stw,sx,g2,ab,cs) :
 
             copy_temp_file("bls192.c", fnamec)
             copy_keep_file("bls192.h", fnameh)
- 
+
             replace(fnamec,"ZZZ",tc)
             replace(fnamec,"YYY",tf)
             replace(fnamec,"XXX",bd)
@@ -659,7 +659,7 @@ def curveset(nbt,tf,tc,base,m8,rz,mt,qi,ct,ca,pf,stw,sx,g2,ab,cs) :
 
             copy_temp_file("fp8.c", fnamec)
             copy_keep_file("fp8.h", fnameh)
- 
+
             replace(fnamec,"YYY",tf)
             replace(fnamec,"XXX",bd)
             replace(fnamec,"ZZZ",tc)
@@ -691,7 +691,7 @@ def curveset(nbt,tf,tc,base,m8,rz,mt,qi,ct,ca,pf,stw,sx,g2,ab,cs) :
 
             copy_temp_file("fp16.c", fnamec)
             copy_keep_file("fp16.h", fnameh)
- 
+
             replace(fnamec,"YYY",tf)
             replace(fnamec,"XXX",bd)
             replace(fnamec,"ZZZ",tc)
@@ -706,7 +706,7 @@ def curveset(nbt,tf,tc,base,m8,rz,mt,qi,ct,ca,pf,stw,sx,g2,ab,cs) :
 
             copy_temp_file("fp48.c", fnamec)
             copy_keep_file("fp48.h", fnameh)
- 
+
             replace(fnamec,"YYY",tf)
             replace(fnamec,"XXX",bd)
             replace(fnamec,"ZZZ",tc)
@@ -721,7 +721,7 @@ def curveset(nbt,tf,tc,base,m8,rz,mt,qi,ct,ca,pf,stw,sx,g2,ab,cs) :
 
             copy_temp_file("pair8.c", fnamec)
             copy_keep_file("pair8.h", fnameh)
-  
+
             replace(fnamec,"ZZZ",tc)
             replace(fnamec,"YYY",tf)
             replace(fnamec,"XXX",bd)
@@ -751,7 +751,7 @@ def curveset(nbt,tf,tc,base,m8,rz,mt,qi,ct,ca,pf,stw,sx,g2,ab,cs) :
 
             copy_temp_file("bls256.c", fnamec)
             copy_keep_file("bls256.h", fnameh)
- 
+
             replace(fnamec,"ZZZ",tc)
             replace(fnamec,"YYY",tf)
             replace(fnamec,"XXX",bd)


### PR DESCRIPTION
The python config script function `interactive_prompt_input` recursed on error, requiring a balanced number of `0` entries to exit cleanly. This is unnecessary, since the prompt body itself already loops and can just fall through to the next iteration to re-prompt after an error.

This removes the recursive call so entering zero to finish scheme selection exits promptly.

Also removes trailing whitespace from python source files.